### PR TITLE
Add ML platform Next.js frontend with model performance workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/ml-platform/node_modules
 /.pnp
 .pnp.js
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+# Aurora AI ML Platform Frontend
+
+A new Next.js + Material UI frontend lives in the `ml-platform` directory. It implements the Aurora AI control center layout along with the model performance and comparison workspace.
+
+## Getting Started (ML Platform)
+
+1. Install dependencies
+
+   ```bash
+   cd ml-platform
+   npm install
+   ```
+
+2. Start the development server
+
+   ```bash
+   npm run dev
+   ```
+
+3. Open `http://localhost:3000` in your browser to explore the dashboard.
+
+---
+
 # Calcium Imaging Analysis Suite
 
 A web application for analyzing calcium imaging data from microscopy videos. This application allows users to:

--- a/ml-platform/app/dashboard/page.tsx
+++ b/ml-platform/app/dashboard/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Box, Grid, Paper, Typography } from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import StorageIcon from '@mui/icons-material/Storage';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+
+const metrics = [
+  {
+    title: 'Active Projects',
+    value: '12',
+    caption: '3 new this week',
+    icon: <RocketLaunchIcon color="primary" />
+  },
+  {
+    title: 'Models in Production',
+    value: '8',
+    caption: 'Accuracy avg 92%',
+    icon: <TrendingUpIcon color="success" />
+  },
+  {
+    title: 'Storage Utilization',
+    value: '2.3 TB',
+    caption: '65% of quota',
+    icon: <StorageIcon color="warning" />
+  }
+];
+
+export default function DashboardPage() {
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <Typography variant="h4" fontWeight={600} color="primary.light">
+        Welcome back, Analyst
+      </Typography>
+      <Typography variant="body1" color="text.secondary">
+        Track your machine learning initiatives at a glance.
+      </Typography>
+      <Grid container spacing={3}>
+        {metrics.map(metric => (
+          <Grid item key={metric.title} xs={12} sm={6} md={4}>
+            <Paper elevation={2} sx={{ p: 3, backgroundColor: 'background.paper' }}>
+              <Box display="flex" alignItems="center" gap={2}>
+                {metric.icon}
+                <Box>
+                  <Typography variant="overline" color="text.secondary">
+                    {metric.title}
+                  </Typography>
+                  <Typography variant="h5" fontWeight={600} color="text.primary">
+                    {metric.value}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {metric.caption}
+                  </Typography>
+                </Box>
+              </Box>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/ml-platform/app/data/exploration/page.tsx
+++ b/ml-platform/app/data/exploration/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function DataExplorationPage() {
+  return (
+    <ComingSoon
+      title="Exploratory Data Analysis"
+      description="Interactive profiling, feature statistics, and visual diagnostics are under construction."
+    />
+  );
+}

--- a/ml-platform/app/data/splitting/page.tsx
+++ b/ml-platform/app/data/splitting/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function DataSplittingPage() {
+  return (
+    <ComingSoon
+      title="Dataset Splitting"
+      description="Configure stratified training, validation, and test splits with visual distribution feedback soon."
+    />
+  );
+}

--- a/ml-platform/app/data/upload/page.tsx
+++ b/ml-platform/app/data/upload/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function DataUploadPage() {
+  return (
+    <ComingSoon
+      title="Data Upload & Preprocessing"
+      description="Drag-and-drop ingest, validation, and preprocessing recipes will appear here."
+    />
+  );
+}

--- a/ml-platform/app/deployments/page.tsx
+++ b/ml-platform/app/deployments/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function DeploymentsPage() {
+  return (
+    <ComingSoon
+      title="Model Deployment"
+      description="Manage inference endpoints, rollout strategies, and real-time monitoring from this console soon."
+    />
+  );
+}

--- a/ml-platform/app/experiments/page.tsx
+++ b/ml-platform/app/experiments/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function ExperimentsPage() {
+  return (
+    <ComingSoon
+      title="Experiment Tracking"
+      description="Compare experiment runs, parameters, and outcomes with advanced filtering coming soon."
+    />
+  );
+}

--- a/ml-platform/app/globals.css
+++ b/ml-platform/app/globals.css
@@ -10,7 +10,7 @@ body {
 
 body {
   margin: 0;
-  font-family: 'Inter', 'Noto Sans', sans-serif;
+  font-family: var(--font-inter), var(--font-noto-sans), sans-serif;
   background-color: #0f141a;
   color: #f5f7fa;
 }

--- a/ml-platform/app/globals.css
+++ b/ml-platform/app/globals.css
@@ -1,0 +1,29 @@
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Noto Sans', sans-serif;
+  background-color: #0f141a;
+  color: #f5f7fa;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+#__next {
+  min-height: 100vh;
+}

--- a/ml-platform/app/layout.tsx
+++ b/ml-platform/app/layout.tsx
@@ -3,6 +3,10 @@ import './globals.css';
 import ThemeRegistry from '@/theme/ThemeRegistry';
 import AppProviders from '@/contexts/AppProviders';
 import AppLayout from '@/components/layout/AppLayout';
+import { Inter, Noto_Sans } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' });
+const notoSans = Noto_Sans({ subsets: ['latin'], variable: '--font-noto-sans', display: 'swap' });
 
 export const metadata: Metadata = {
   title: 'ML Platform Dashboard',
@@ -12,7 +16,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body className={`${inter.variable} ${notoSans.variable}`}>
         <ThemeRegistry>
           <AppProviders>
             <AppLayout>{children}</AppLayout>

--- a/ml-platform/app/layout.tsx
+++ b/ml-platform/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import ThemeRegistry from '@/theme/ThemeRegistry';
+import AppProviders from '@/contexts/AppProviders';
+import AppLayout from '@/components/layout/AppLayout';
+
+export const metadata: Metadata = {
+  title: 'ML Platform Dashboard',
+  description: 'Comprehensive machine learning operations platform'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ThemeRegistry>
+          <AppProviders>
+            <AppLayout>{children}</AppLayout>
+          </AppProviders>
+        </ThemeRegistry>
+      </body>
+    </html>
+  );
+}

--- a/ml-platform/app/models/interpretability/page.tsx
+++ b/ml-platform/app/models/interpretability/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function ModelInterpretabilityPage() {
+  return (
+    <ComingSoon
+      title="Model Interpretability"
+      description="Feature attributions, SHAP plots, and counterfactual analysis dashboards are being crafted."
+    />
+  );
+}

--- a/ml-platform/app/models/optimization/page.tsx
+++ b/ml-platform/app/models/optimization/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function ModelOptimizationPage() {
+  return (
+    <ComingSoon
+      title="Hyperparameter Optimization"
+      description="Grid, random, and Bayesian search orchestration will be available here shortly."
+    />
+  );
+}

--- a/ml-platform/app/models/performance/page.tsx
+++ b/ml-platform/app/models/performance/page.tsx
@@ -1,0 +1,9 @@
+import ModelPerformancePage from '@/components/models/performance/ModelPerformancePage';
+
+export const metadata = {
+  title: 'Model Performance & Comparison'
+};
+
+export default function ModelPerformance() {
+  return <ModelPerformancePage />;
+}

--- a/ml-platform/app/models/training/page.tsx
+++ b/ml-platform/app/models/training/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function ModelTrainingPage() {
+  return (
+    <ComingSoon
+      title="Model Selection & Training"
+      description="Design experiments, configure hyperparameters, and launch training jobs from this workspace soon."
+    />
+  );
+}

--- a/ml-platform/app/page.tsx
+++ b/ml-platform/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function IndexPage() {
+  redirect('/dashboard');
+}

--- a/ml-platform/app/projects/page.tsx
+++ b/ml-platform/app/projects/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function ProjectsPage() {
+  return (
+    <ComingSoon
+      title="Project Portfolio"
+      description="Organize collaborative ML initiatives, contributors, and assets in this upcoming view."
+    />
+  );
+}

--- a/ml-platform/app/workflows/page.tsx
+++ b/ml-platform/app/workflows/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import ComingSoon from '@/components/common/ComingSoon';
+
+export default function WorkflowsPage() {
+  return (
+    <ComingSoon
+      title="Automation Workflows"
+      description="Visual pipeline orchestration, scheduling, and monitoring will be introduced here soon."
+    />
+  );
+}

--- a/ml-platform/next-env.d.ts
+++ b/ml-platform/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/ml-platform/next.config.js
+++ b/ml-platform/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/ml-platform/package.json
+++ b/ml-platform/package.json
@@ -11,8 +11,6 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.3",
-    "@fontsource-variable/inter": "^5.0.8",
-    "@fontsource/noto-sans": "^5.0.0",
     "@mui/icons-material": "^5.15.15",
     "@mui/material": "^5.15.15",
     "@mui/material-nextjs": "^5.15.15",

--- a/ml-platform/package.json
+++ b/ml-platform/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ml-platform-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.3",
+    "@fontsource/inter": "^5.0.0",
+    "@fontsource/noto-sans": "^5.0.0",
+    "@mui/icons-material": "^5.15.15",
+    "@mui/material": "^5.15.15",
+    "@mui/material-nextjs": "^5.15.15",
+    "@tanstack/react-query": "^4.36.1",
+    "clsx": "^2.1.0",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.8.3",
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "^2.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.41",
+    "@types/react-dom": "^18.2.17",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "13.5.6",
+    "typescript": "^5.3.3"
+  }
+}

--- a/ml-platform/package.json
+++ b/ml-platform/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.3",
-    "@fontsource/inter": "^5.0.0",
+    "@fontsource-variable/inter": "^5.0.8",
     "@fontsource/noto-sans": "^5.0.0",
     "@mui/icons-material": "^5.15.15",
     "@mui/material": "^5.15.15",

--- a/ml-platform/src/components/common/ComingSoon.tsx
+++ b/ml-platform/src/components/common/ComingSoon.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Paper, Typography } from '@mui/material';
+import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
+
+interface ComingSoonProps {
+  title: string;
+  description: string;
+}
+
+export default function ComingSoon({ title, description }: ComingSoonProps) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        px: { xs: 3, md: 6 },
+        py: { xs: 4, md: 6 },
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: 2,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <AccessTimeOutlinedIcon sx={{ fontSize: 48, color: 'primary.light' }} />
+      <Typography variant="h5" fontWeight={600} color="text.primary">
+        {title}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" maxWidth={480}>
+        {description}
+      </Typography>
+    </Paper>
+  );
+}

--- a/ml-platform/src/components/common/MetricCard.tsx
+++ b/ml-platform/src/components/common/MetricCard.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { alpha, Box, Chip, LinearProgress, Paper, Stack, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+
+interface MetricCardProps {
+  title: string;
+  value: string;
+  subtitle?: string;
+  icon?: ReactNode;
+  trend?: 'up' | 'down' | 'stable';
+  trendValue?: string;
+  progress?: number;
+  color?: 'primary' | 'success' | 'warning' | 'error';
+}
+
+const trendCopy: Record<NonNullable<MetricCardProps['trend']>, string> = {
+  up: 'increase',
+  down: 'decrease',
+  stable: 'no change'
+};
+
+export default function MetricCard({
+  title,
+  value,
+  subtitle,
+  icon,
+  trend = 'stable',
+  trendValue,
+  progress,
+  color = 'primary'
+}: MetricCardProps) {
+  const showTrend = Boolean(trendValue);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={2}>
+        {icon && (
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: theme => alpha(theme.palette[color].main, 0.16),
+              color: `${color}.main`
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        <Box>
+          <Typography variant="overline" color="text.secondary" letterSpacing={0.6}>
+            {title}
+          </Typography>
+          <Typography variant="h5" fontWeight={700} color="text.primary">
+            {value}
+          </Typography>
+          {subtitle && (
+            <Typography variant="body2" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+      </Stack>
+      {progress !== undefined && (
+        <Box>
+          <LinearProgress
+            variant="determinate"
+            value={progress}
+            sx={{
+              height: 6,
+              borderRadius: 999,
+              backgroundColor: 'rgba(255,255,255,0.08)'
+            }}
+            color={color}
+          />
+        </Box>
+      )}
+      {showTrend && (
+        <Chip
+          size="small"
+          color={trend === 'down' ? 'error' : trend === 'up' ? 'success' : 'default'}
+          label={`${trendValue} ${trendCopy[trend]}`}
+          sx={{ alignSelf: 'flex-start' }}
+        />
+      )}
+    </Paper>
+  );
+}

--- a/ml-platform/src/components/layout/AppLayout.tsx
+++ b/ml-platform/src/components/layout/AppLayout.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { useState } from 'react';
+import Sidebar, { drawerWidth } from './Sidebar';
+import Header from './Header';
+import Breadcrumbs from './Breadcrumbs';
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', backgroundColor: 'background.default' }}>
+      <Sidebar open={mobileOpen} onClose={() => setMobileOpen(false)} />
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          ml: { lg: `${drawerWidth}px` },
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh'
+        }}
+      >
+        <Header onMenuClick={() => setMobileOpen(true)} />
+        <Box component="section" sx={{ px: { xs: 2, md: 4 }, py: 3, flexGrow: 1 }}>
+          <Breadcrumbs />
+          <Box mt={3} display="flex" flexDirection="column" gap={3}>
+            {children}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/ml-platform/src/components/layout/Breadcrumbs.tsx
+++ b/ml-platform/src/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import NextLink from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Breadcrumbs as MuiBreadcrumbs, Link, Typography } from '@mui/material';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+
+const formatSegment = (segment: string) =>
+  segment
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+export default function Breadcrumbs() {
+  const pathname = usePathname();
+  const segments = pathname.split('/').filter(Boolean);
+
+  return (
+    <MuiBreadcrumbs
+      separator={<NavigateNextIcon fontSize="small" sx={{ color: 'text.disabled' }} />}
+      aria-label="breadcrumb"
+      sx={{ color: 'text.secondary', fontSize: 14 }}
+    >
+      <Link
+        component={NextLink}
+        href="/dashboard"
+        color="text.secondary"
+        underline="hover"
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+      >
+        <HomeOutlinedIcon sx={{ fontSize: 18 }} />
+        Home
+      </Link>
+      {segments.map((segment, index) => {
+        const href = `/${segments.slice(0, index + 1).join('/')}`;
+        const isLast = index === segments.length - 1;
+        return isLast ? (
+          <Typography key={href} color="text.primary" fontWeight={600} fontSize={14}>
+            {formatSegment(segment)}
+          </Typography>
+        ) : (
+          <Link
+            key={href}
+            component={NextLink}
+            href={href}
+            color="text.secondary"
+            underline="hover"
+            sx={{ fontSize: 14 }}
+          >
+            {formatSegment(segment)}
+          </Link>
+        );
+      })}
+    </MuiBreadcrumbs>
+  );
+}

--- a/ml-platform/src/components/layout/Header.tsx
+++ b/ml-platform/src/components/layout/Header.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import {
+  alpha,
+  Avatar,
+  Badge,
+  Box,
+  IconButton,
+  InputBase,
+  Stack,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import SearchIcon from '@mui/icons-material/Search';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+
+interface HeaderProps {
+  onMenuClick: () => void;
+}
+
+export default function Header({ onMenuClick }: HeaderProps) {
+  return (
+    <Box
+      component="header"
+      sx={{
+        height: 72,
+        display: 'flex',
+        alignItems: 'center',
+        px: 3,
+        gap: 3,
+        backdropFilter: 'blur(12px)',
+        backgroundColor: alpha('#111418', 0.85),
+        borderBottom: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <IconButton onClick={onMenuClick} sx={{ display: { lg: 'none' } }} color="inherit">
+        <MenuIcon />
+      </IconButton>
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          backgroundColor: alpha('#ffffff', 0.04),
+          px: 2,
+          py: 1,
+          borderRadius: 2
+        }}
+      >
+        <SearchIcon sx={{ color: 'text.secondary' }} />
+        <InputBase
+          placeholder="Search projects, models, datasets..."
+          sx={{ flex: 1, color: 'text.primary' }}
+          inputProps={{ 'aria-label': 'search' }}
+        />
+      </Box>
+      <Stack direction="row" alignItems="center" spacing={1.5}>
+        <Tooltip title="Support">
+          <IconButton color="inherit">
+            <HelpOutlineOutlinedIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Notifications">
+          <IconButton color="inherit">
+            <Badge color="error" variant="dot" overlap="circular">
+              <NotificationsNoneOutlinedIcon />
+            </Badge>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Settings">
+          <IconButton color="inherit">
+            <SettingsOutlinedIcon />
+          </IconButton>
+        </Tooltip>
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+          <Box textAlign="right">
+            <Typography variant="subtitle2" color="text.primary">
+              Jordan Williams
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Lead ML Engineer
+            </Typography>
+          </Box>
+          <Avatar src="https://i.pravatar.cc/100?img=5" alt="Jordan Williams" />
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/ml-platform/src/components/layout/Sidebar.tsx
+++ b/ml-platform/src/components/layout/Sidebar.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import {
+  Box,
+  Chip,
+  Divider,
+  Drawer,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Typography
+} from '@mui/material';
+import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined';
+import CloudUploadOutlinedIcon from '@mui/icons-material/CloudUploadOutlined';
+import InsightsOutlinedIcon from '@mui/icons-material/InsightsOutlined';
+import ScatterPlotOutlinedIcon from '@mui/icons-material/ScatterPlotOutlined';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import LeaderboardOutlinedIcon from '@mui/icons-material/LeaderboardOutlined';
+import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
+import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
+import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import SettingsSuggestOutlinedIcon from '@mui/icons-material/SettingsSuggestOutlined';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { NavSection } from '@/types/navigation';
+
+const drawerWidth = 288;
+
+const navSections: NavSection[] = [
+  {
+    title: 'Overview',
+    items: [
+      {
+        title: 'Dashboard',
+        path: '/dashboard',
+        icon: <DashboardOutlinedIcon />
+      },
+      {
+        title: 'Data Upload',
+        path: '/data/upload',
+        icon: <CloudUploadOutlinedIcon />
+      },
+      {
+        title: 'Exploration & EDA',
+        path: '/data/exploration',
+        icon: <InsightsOutlinedIcon />
+      },
+      {
+        title: 'Dataset Splits',
+        path: '/data/splitting',
+        icon: <ScatterPlotOutlinedIcon />
+      }
+    ]
+  },
+  {
+    title: 'Models',
+    items: [
+      {
+        title: 'Model Training',
+        path: '/models/training',
+        icon: <ScienceOutlinedIcon />
+      },
+      {
+        title: 'Hyperparameter Optimization',
+        path: '/models/optimization',
+        icon: <TuneOutlinedIcon />
+      },
+      {
+        title: 'Performance & Comparison',
+        path: '/models/performance',
+        icon: <LeaderboardOutlinedIcon />,
+        badge: 'New'
+      },
+      {
+        title: 'Interpretability',
+        path: '/models/interpretability',
+        icon: <LightbulbOutlinedIcon />
+      }
+    ]
+  },
+  {
+    title: 'Operations',
+    items: [
+      {
+        title: 'Deployments',
+        path: '/deployments',
+        icon: <CloudOutlinedIcon />
+      },
+      {
+        title: 'Projects',
+        path: '/projects',
+        icon: <GroupOutlinedIcon />
+      },
+      {
+        title: 'Experiment Tracking',
+        path: '/experiments',
+        icon: <AssessmentOutlinedIcon />
+      },
+      {
+        title: 'Workflows',
+        path: '/workflows',
+        icon: <SettingsSuggestOutlinedIcon />
+      }
+    ]
+  }
+];
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
+  const pathname = usePathname();
+
+  const content = (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: 'background.default'
+      }}
+    >
+      <Box px={3} py={4} display="flex" flexDirection="column" gap={1}>
+        <Typography variant="subtitle2" color="text.secondary">
+          ML Platform
+        </Typography>
+        <Typography variant="h5" fontWeight={700} color="text.primary">
+          Aurora AI Control Center
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          End-to-end machine learning lifecycle management
+        </Typography>
+      </Box>
+      <Divider sx={{ borderColor: 'divider', opacity: 0.2 }} />
+      <Box flex={1} overflow="auto">
+        {navSections.map(section => (
+          <List
+            key={section.title}
+            subheader={
+              <ListSubheader
+                component="div"
+                disableSticky
+                sx={{
+                  background: 'transparent',
+                  color: 'text.secondary',
+                  fontWeight: 600,
+                  letterSpacing: 0.5
+                }}
+              >
+                {section.title}
+              </ListSubheader>
+            }
+            sx={{
+              '& .MuiListItemButton-root': {
+                borderRadius: 2,
+                mx: 1,
+                mb: 0.5
+              }
+            }}
+          >
+            {section.items.map(item => {
+              const isActive = pathname.startsWith(item.path);
+              return (
+                <ListItemButton
+                  key={item.title}
+                  component={Link}
+                  href={item.path}
+                  onClick={onClose}
+                  selected={isActive}
+                  sx={{
+                    color: isActive ? 'primary.contrastText' : 'text.secondary',
+                    bgcolor: isActive ? 'primary.main' : 'transparent'
+                  }}
+                >
+                  <ListItemIcon sx={{ color: isActive ? 'primary.contrastText' : 'text.secondary' }}>
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={item.title}
+                    primaryTypographyProps={{ fontWeight: isActive ? 600 : 500 }}
+                  />
+                  {item.badge && (
+                    <Chip size="small" color="secondary" label={item.badge} sx={{ ml: 1 }} />
+                  )}
+                </ListItemButton>
+              );
+            })}
+          </List>
+        ))}
+      </Box>
+      <Box px={3} py={3}>
+        <Typography variant="caption" color="text.secondary">
+          Aurora AI Platform © {new Date().getFullYear()}
+        </Typography>
+      </Box>
+    </Box>
+  );
+
+  return (
+    <>
+      <Drawer
+        variant="temporary"
+        open={open}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: 'block', lg: 'none' },
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            backgroundColor: 'background.paper',
+            borderRight: '1px solid rgba(255,255,255,0.08)'
+          }
+        }}
+      >
+        {content}
+      </Drawer>
+      <Drawer
+        variant="permanent"
+        open
+        sx={{
+          display: { xs: 'none', lg: 'block' },
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            backgroundColor: 'background.paper',
+            borderRight: '1px solid rgba(255,255,255,0.08)',
+            boxSizing: 'border-box'
+          }
+        }}
+      >
+        {content}
+      </Drawer>
+    </>
+  );
+}
+
+export { drawerWidth };

--- a/ml-platform/src/components/models/performance/ModelPerformancePage.tsx
+++ b/ml-platform/src/components/models/performance/ModelPerformancePage.tsx
@@ -1,0 +1,790 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Slider,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import TableChartOutlinedIcon from '@mui/icons-material/TableChartOutlined';
+import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import TrendingUpOutlinedIcon from '@mui/icons-material/TrendingUpOutlined';
+import InsightsOutlinedIcon from '@mui/icons-material/InsightsOutlined';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import { useQuery } from '@tanstack/react-query';
+import { fetchModelPerformance } from '@/services/mock/performanceData';
+import MetricCard from '@/components/common/MetricCard';
+import { ModelSummary, PerformanceRun, PredictionRecord } from '@/types/performance';
+import { exportModelSummaryPdf, exportPredictionsToCSV } from '@/utils/exportUtils';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { alpha } from '@mui/material/styles';
+
+const metricDescriptors = [
+  { key: 'accuracy', label: 'Accuracy', icon: <TrendingUpOutlinedIcon /> },
+  { key: 'precision', label: 'Precision', icon: <ScienceOutlinedIcon /> },
+  { key: 'recall', label: 'Recall', icon: <TimelineOutlinedIcon /> },
+  { key: 'rocAuc', label: 'ROC AUC', icon: <InsightsOutlinedIcon /> }
+] as const;
+
+type MetricKey = (typeof metricDescriptors)[number]['key'];
+
+type ConfusionMatrixCell = {
+  label: string;
+  value: number;
+  percentage: number;
+};
+
+const rocColors = ['#1173d4', '#4caf50', '#ff9800', '#f44336'];
+
+function formatPercentage(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function buildConfusionCells(run: PerformanceRun): ConfusionMatrixCell[][] {
+  const total = run.confusionMatrix.values.flat().reduce((sum, cell) => sum + cell, 0);
+  return run.confusionMatrix.values.map((row, rowIndex) =>
+    row.map((value, columnIndex) => ({
+      label: `${run.confusionMatrix.labels[rowIndex]} → ${run.confusionMatrix.labels[columnIndex]}`,
+      value,
+      percentage: value / total
+    }))
+  );
+}
+
+function ModelMetricsComparison({ models }: { models: ModelSummary[] }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 3,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack spacing={0.5}>
+          <Typography variant="h6" color="text.primary" fontWeight={600}>
+            Model Comparison
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Evaluate performance metrics across selected models side by side.
+          </Typography>
+        </Stack>
+        <Chip label={`${models.length} models`} color="primary" variant="outlined" />
+      </Stack>
+      {models.length > 0 ? (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Model</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell align="center">Accuracy</TableCell>
+              <TableCell align="center">Precision</TableCell>
+              <TableCell align="center">Recall</TableCell>
+              <TableCell align="center">F1 Score</TableCell>
+              <TableCell align="center">ROC AUC</TableCell>
+              <TableCell align="center">Log Loss</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {models.map(model => (
+              <TableRow key={model.id} hover>
+                <TableCell>
+                  <Stack spacing={0.5}>
+                    <Typography variant="subtitle2" color="text.primary" fontWeight={600}>
+                      {model.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Version {model.version} · {new Date(model.updatedAt).toLocaleString()}
+                    </Typography>
+                  </Stack>
+                </TableCell>
+                <TableCell>{model.type}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.accuracy)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.precision)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.recall)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.f1Score)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.rocAuc)}</TableCell>
+                <TableCell align="center">{model.metrics.logLoss.toFixed(3)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Paper
+          variant="outlined"
+          sx={{ p: 4, textAlign: 'center', backgroundColor: 'rgba(255,255,255,0.02)' }}
+        >
+          <Typography variant="subtitle1" color="text.primary" fontWeight={600} gutterBottom>
+            Select models to compare
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Choose one or more models from the filters above to unlock the comparison matrix.
+          </Typography>
+        </Paper>
+      )}
+    </Paper>
+  );
+}
+
+function ConfusionMatrixCard({ run }: { run: PerformanceRun }) {
+  const cells = buildConfusionCells(run);
+  const totals = run.confusionMatrix.values.map(row => row.reduce((sum, value) => sum + value, 0));
+  const columnTotals = run.confusionMatrix.values[0].map((_, columnIndex) =>
+    run.confusionMatrix.values.reduce((sum, row) => sum + row[columnIndex], 0)
+  );
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        height: '100%',
+        border: '1px solid rgba(255,255,255,0.08)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2
+      }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack spacing={0.5}>
+          <Typography variant="h6" fontWeight={600}>
+            Confusion Matrix
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Dataset: {run.dataset}
+          </Typography>
+        </Stack>
+        <Chip size="small" label={`Updated ${new Date(run.createdAt).toLocaleString()}`} variant="outlined" />
+      </Stack>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Actual / Predicted</TableCell>
+            {run.confusionMatrix.labels.map(label => (
+              <TableCell key={label} align="center">
+                {label}
+              </TableCell>
+            ))}
+            <TableCell align="center">Total</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {cells.map((row, rowIndex) => (
+            <TableRow key={run.confusionMatrix.labels[rowIndex]}>
+              <TableCell>{run.confusionMatrix.labels[rowIndex]}</TableCell>
+              {row.map((cell, columnIndex) => (
+                <TableCell
+                  key={cell.label}
+                  align="center"
+                  sx={{
+                    backgroundColor: theme => alpha(theme.palette.primary.main, 0.08 + cell.percentage * 0.5),
+                    borderRadius: 1
+                  }}
+                >
+                  <Stack spacing={0.5}>
+                    <Typography variant="body2" fontWeight={600}>
+                      {cell.value}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {(cell.percentage * 100).toFixed(1)}%
+                    </Typography>
+                  </Stack>
+                </TableCell>
+              ))}
+              <TableCell align="center" sx={{ fontWeight: 600 }}>
+                {totals[rowIndex]}
+              </TableCell>
+            </TableRow>
+          ))}
+          <TableRow>
+            <TableCell>Total</TableCell>
+            {columnTotals.map((total, index) => (
+              <TableCell key={`col-${index}`} align="center" sx={{ fontWeight: 600 }}>
+                {total}
+              </TableCell>
+            ))}
+            <TableCell align="center" sx={{ fontWeight: 700 }}>
+              {totals.reduce((sum, value) => sum + value, 0)}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+}
+
+interface PredictionTableProps {
+  predictions: PredictionRecord[];
+  models: ModelSummary[];
+  selectedModelId: string;
+  onChangeModel: (modelId: string) => void;
+  threshold: number;
+  onThresholdChange: (value: number) => void;
+  onlyMisclassified: boolean;
+  onToggleMisclassified: (value: boolean) => void;
+}
+
+function PredictionTable({
+  predictions,
+  models,
+  selectedModelId,
+  onChangeModel,
+  threshold,
+  onThresholdChange,
+  onlyMisclassified,
+  onToggleMisclassified
+}: PredictionTableProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const filteredPredictions = useMemo(() => {
+    return predictions
+      .filter(pred => pred.modelId === selectedModelId)
+      .filter(pred => (onlyMisclassified ? pred.actual !== pred.predicted : true))
+      .filter(pred => pred.probability >= threshold)
+      .slice(0, 12);
+  }, [predictions, selectedModelId, onlyMisclassified, threshold]);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }}>
+        <Stack spacing={0.5} flex={1}>
+          <Typography variant="h6" fontWeight={600}>
+            Prediction Drill-down
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Review recent predictions and explore contributing features for transparency.
+          </Typography>
+        </Stack>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center">
+          <FormControl size="small" sx={{ minWidth: 200 }}>
+            <InputLabel id="prediction-model-label">Model</InputLabel>
+            <Select
+              labelId="prediction-model-label"
+              value={selectedModelId}
+              label="Model"
+              onChange={event => onChangeModel(event.target.value)}
+            >
+              {models.map(model => (
+                <MenuItem key={model.id} value={model.id}>
+                  {model.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Typography variant="caption">Show misclassifications</Typography>
+            <Switch
+              checked={onlyMisclassified}
+              onChange={(_, checked) => onToggleMisclassified(checked)}
+              inputProps={{ 'aria-label': 'show only misclassified predictions' }}
+            />
+          </Stack>
+        </Stack>
+      </Stack>
+      <Stack spacing={1.5}>
+        <Typography variant="caption" color="text.secondary">
+          Probability threshold: {(threshold * 100).toFixed(0)}%
+        </Typography>
+        <Slider
+          value={threshold}
+          onChange={(_, value) => onThresholdChange(value as number)}
+          min={0.5}
+          max={0.95}
+          step={0.05}
+          valueLabelDisplay="auto"
+          valueLabelFormat={value => `${Math.round((value as number) * 100)}%`}
+          marks={[
+            { value: 0.5, label: '50%' },
+            { value: 0.65, label: '65%' },
+            { value: 0.8, label: '80%' },
+            { value: 0.95, label: '95%' }
+          ]}
+        />
+        <Typography variant="caption" color="text.secondary">
+          Drag the slider to focus on high-confidence predictions for error analysis.
+        </Typography>
+      </Stack>
+      <Divider sx={{ borderColor: 'rgba(255,255,255,0.08)' }} />
+      <Stack spacing={1}>
+        {filteredPredictions.map(prediction => {
+          const misclassified = prediction.actual !== prediction.predicted;
+          return (
+            <Accordion
+              key={prediction.id}
+              expanded={expanded === prediction.id}
+              onChange={(_, isExpanded) => setExpanded(isExpanded ? prediction.id : null)}
+              disableGutters
+              sx={{
+                backgroundColor: 'transparent',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 2,
+                '&:before': { display: 'none' }
+              }}
+            >
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Stack
+                  direction={{ xs: 'column', md: 'row' }}
+                  spacing={2}
+                  flex={1}
+                  alignItems={{ xs: 'flex-start', md: 'center' }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="center" flex={1}>
+                    {misclassified && <WarningAmberOutlinedIcon color="warning" fontSize="small" />}
+                    <Box>
+                      <Typography variant="subtitle2" color="text.primary" fontWeight={600}>
+                        Prediction {prediction.id}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {new Date(prediction.timestamp).toLocaleString()}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                  <Chip
+                    label={`Actual: ${prediction.actual}`}
+                    color="secondary"
+                    variant="outlined"
+                    sx={{ minWidth: 120 }}
+                  />
+                  <Chip
+                    label={`Predicted: ${prediction.predicted}`}
+                    color={misclassified ? 'warning' : 'success'}
+                    variant={misclassified ? 'outlined' : 'filled'}
+                    sx={{ minWidth: 140 }}
+                  />
+                  <Chip
+                    label={`Confidence ${(prediction.probability * 100).toFixed(0)}%`}
+                    color="primary"
+                    variant="outlined"
+                    sx={{ minWidth: 160 }}
+                  />
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  {Object.entries(prediction.features).map(([feature, value]) => (
+                    <Grid item xs={12} sm={6} md={3} key={feature}>
+                      <Paper
+                        variant="outlined"
+                        sx={{
+                          p: 2,
+                          borderRadius: 2,
+                          backgroundColor: alpha('#ffffff', 0.02)
+                        }}
+                      >
+                        <Typography variant="caption" color="text.secondary" textTransform="uppercase">
+                          {feature}
+                        </Typography>
+                        <Typography variant="subtitle1" color="text.primary" fontWeight={600}>
+                          {value}
+                        </Typography>
+                      </Paper>
+                    </Grid>
+                  ))}
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+          );
+        })}
+        {filteredPredictions.length === 0 && (
+          <Paper
+            variant="outlined"
+            sx={{ p: 4, textAlign: 'center', backgroundColor: 'rgba(255,255,255,0.02)' }}
+          >
+            <Typography variant="subtitle1" color="text.primary" fontWeight={600} gutterBottom>
+              No predictions match the current filters
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Adjust the confidence threshold or toggle misclassifications to explore more predictions.
+            </Typography>
+          </Paper>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+export default function ModelPerformancePage() {
+  const { data, isLoading } = useQuery(['model-performance'], fetchModelPerformance);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
+  const [selectedDataset, setSelectedDataset] = useState<string>('');
+  const [selectedMetric, setSelectedMetric] = useState<MetricKey>('accuracy');
+  const [predictionModelId, setPredictionModelId] = useState<string>('');
+  const [threshold, setThreshold] = useState<number>(0.6);
+  const [onlyMisclassified, setOnlyMisclassified] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (data && selectedModelIds.length === 0) {
+      const initialModels = data.models.slice(0, 2).map(model => model.id);
+      setSelectedModelIds(initialModels);
+      setPredictionModelId(initialModels[0]);
+    }
+    if (data && !selectedDataset) {
+      setSelectedDataset(data.models[0]?.dataset ?? '');
+    }
+  }, [data, selectedModelIds.length, selectedDataset]);
+
+  const datasetOptions = useMemo(
+    () => Array.from(new Set(data?.models.map(model => model.dataset) ?? [])),
+    [data]
+  );
+
+  const datasetModels = useMemo(
+    () => data?.models.filter(model => !selectedDataset || model.dataset === selectedDataset) ?? [],
+    [data, selectedDataset]
+  );
+
+  const selectedModels = useMemo(
+    () => datasetModels.filter(model => selectedModelIds.includes(model.id)),
+    [datasetModels, selectedModelIds]
+  );
+
+  const selectedRuns = useMemo(
+    () =>
+      data?.performanceRuns.filter(run => selectedModelIds.includes(run.modelId) && run.dataset === selectedDataset) ?? [],
+    [data, selectedModelIds, selectedDataset]
+  );
+
+  const metricLeaders = useMemo(() => {
+    if (!datasetModels.length) return [];
+    return metricDescriptors.map(descriptor => {
+      const leader = [...datasetModels].sort(
+        (a, b) => b.metrics[descriptor.key] - a.metrics[descriptor.key]
+      )[0];
+      return {
+        descriptor,
+        leader
+      };
+    });
+  }, [datasetModels]);
+
+  const rocSeries = useMemo(() => {
+    return selectedRuns.map(run => ({
+      name: data?.models.find(model => model.id === run.modelId)?.name ?? run.modelId,
+      data: run.roc
+    }));
+  }, [selectedRuns, data]);
+
+  useEffect(() => {
+    if (!datasetModels.length) {
+      if (selectedModelIds.length) {
+        setSelectedModelIds([]);
+      }
+      if (predictionModelId) {
+        setPredictionModelId('');
+      }
+      return;
+    }
+
+    const intersection = selectedModelIds.filter(id =>
+      datasetModels.some(model => model.id === id)
+    );
+
+    if (intersection.length === 0) {
+      const defaults = datasetModels.slice(0, 2).map(model => model.id);
+      if (defaults.length) {
+        setSelectedModelIds(defaults);
+        setPredictionModelId(defaults[0]);
+      }
+    } else if (intersection.length !== selectedModelIds.length) {
+      setSelectedModelIds(intersection);
+    }
+  }, [datasetModels, selectedModelIds, predictionModelId]);
+
+  useEffect(() => {
+    if (selectedModelIds.length && !selectedModelIds.includes(predictionModelId)) {
+      setPredictionModelId(selectedModelIds[0]);
+    }
+  }, [selectedModelIds, predictionModelId]);
+
+  const diagonalPoints = useMemo(
+    () => Array.from({ length: 11 }, (_, index) => ({ fpr: index / 10, tpr: index / 10 })),
+    []
+  );
+
+  const filteredPredictions = data?.predictions ?? [];
+
+  const handleExportCsv = () => {
+    if (!filteredPredictions.length) return;
+    exportPredictionsToCSV(filteredPredictions, 'model-predictions.csv');
+  };
+
+  const handleExportPdf = () => {
+    if (!selectedModels.length) return;
+    exportModelSummaryPdf(selectedModels, 'model-performance-report.pdf');
+  };
+
+  if (isLoading || !data) {
+    return (
+      <Paper sx={{ p: 6, display: 'flex', justifyContent: 'center', backgroundColor: 'rgba(255,255,255,0.04)' }}>
+        <Stack spacing={2} alignItems="center">
+          <CircularProgress color="primary" />
+          <Typography variant="body2" color="text.secondary">
+            Aggregating performance analytics…
+          </Typography>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap={4}>
+      <Paper
+        elevation={0}
+        sx={{
+          p: 3,
+          border: '1px solid rgba(255,255,255,0.08)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 3
+        }}
+      >
+        <Stack direction={{ xs: 'column', lg: 'row' }} spacing={3} alignItems={{ xs: 'flex-start', lg: 'center' }}>
+          <Stack spacing={0.5} flex={1}>
+            <Typography variant="h5" fontWeight={700} color="text.primary">
+              Model Performance Intelligence
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Monitor, compare, and explain how your production models behave across datasets, thresholds, and metrics.
+            </Typography>
+          </Stack>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+            <Button
+              variant="outlined"
+              color="secondary"
+              startIcon={<TableChartOutlinedIcon />}
+              onClick={handleExportCsv}
+            >
+              Export predictions (CSV)
+            </Button>
+            <Button variant="contained" color="primary" startIcon={<DownloadOutlinedIcon />} onClick={handleExportPdf}>
+              Generate PDF Report
+            </Button>
+          </Stack>
+        </Stack>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="dataset-select-label">Dataset</InputLabel>
+            <Select
+              labelId="dataset-select-label"
+              value={selectedDataset}
+              label="Dataset"
+              onChange={event => setSelectedDataset(event.target.value)}
+            >
+              {datasetOptions.map(dataset => (
+                <MenuItem key={dataset} value={dataset}>
+                  {dataset}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel id="metric-select-label">Ranking Metric</InputLabel>
+            <Select
+              labelId="metric-select-label"
+              value={selectedMetric}
+              label="Ranking Metric"
+              onChange={event => setSelectedMetric(event.target.value as MetricKey)}
+            >
+              {metricDescriptors.map(metric => (
+                <MenuItem key={metric.key} value={metric.key}>
+                  {metric.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel id="model-select-label">Compare Models</InputLabel>
+            <Select
+              labelId="model-select-label"
+              multiple
+              value={selectedModelIds}
+              label="Compare Models"
+              onChange={event => {
+                const value = event.target.value as string[];
+                if (!value.length && datasetModels.length) {
+                  const defaults = datasetModels.slice(0, 1).map(model => model.id);
+                  setSelectedModelIds(defaults);
+                  setPredictionModelId(defaults[0]);
+                } else {
+                  setSelectedModelIds(value);
+                  if (value.length && !value.includes(predictionModelId)) {
+                    setPredictionModelId(value[0]);
+                  }
+                }
+              }}
+              renderValue={selected =>
+                selected
+                  .map(id => datasetModels.find(model => model.id === id)?.name ?? id)
+                  .join(', ')
+              }
+            >
+              {datasetModels.map(model => (
+                <MenuItem key={model.id} value={model.id}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Typography variant="body2" color="text.primary">
+                      {model.name}
+                    </Typography>
+                    <Chip label={model.type} size="small" color="secondary" variant="outlined" />
+                  </Stack>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+      </Paper>
+
+      <Grid container spacing={3}>
+        {metricLeaders.map(({ descriptor, leader }) => (
+          <Grid item xs={12} sm={6} lg={3} key={descriptor.key}>
+            <MetricCard
+              title={descriptor.label}
+              value={leader ? formatPercentage(leader.metrics[descriptor.key]) : '--'}
+              subtitle={leader ? leader.name : 'No data'}
+              icon={descriptor.icon}
+              color="primary"
+              trend={selectedMetric === descriptor.key ? 'up' : 'stable'}
+              trendValue={leader ? `${formatPercentage(leader.metrics[descriptor.key])}` : undefined}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      <Grid container spacing={3}>
+        {selectedRuns.map(run => (
+          <Grid item xs={12} md={6} key={run.id}>
+            <ConfusionMatrixCard run={run} />
+          </Grid>
+        ))}
+        <Grid item xs={12} md={selectedRuns.length > 1 ? 12 : 6}>
+          <Paper
+            elevation={0}
+            sx={{
+              p: 3,
+              border: '1px solid rgba(255,255,255,0.08)',
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 3
+            }}
+          >
+            <Stack direction="row" alignItems="center" justifyContent="space-between">
+              <Stack spacing={0.5}>
+                <Typography variant="h6" fontWeight={600}>
+                  ROC Curve
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Compare true positive rates against false positive rates across thresholds.
+                </Typography>
+              </Stack>
+              <Tooltip title="Area under the curve indicates overall model discrimination power.">
+                <IconButton color="inherit">
+                  <InfoOutlinedIcon />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+            <Box sx={{ height: 320 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={diagonalPoints} margin={{ left: 16, right: 16, bottom: 8 }}>
+                  <CartesianGrid stroke="rgba(255,255,255,0.06)" strokeDasharray="3 3" />
+                  <XAxis
+                    type="number"
+                    dataKey="fpr"
+                    domain={[0, 1]}
+                    tickFormatter={value => (value * 100).toFixed(0) + '%'}
+                  />
+                  <YAxis type="number" domain={[0, 1]} tickFormatter={value => (value * 100).toFixed(0) + '%'} />
+                  <RechartsTooltip formatter={value => (Number(value) * 100).toFixed(1) + '%'} />
+                  <Legend />
+                  {rocSeries.map((series, index) => (
+                    <Line
+                      key={series.name}
+                      data={series.data}
+                      dataKey="tpr"
+                      type="monotone"
+                      strokeWidth={2}
+                      stroke={rocColors[index % rocColors.length]}
+                      dot={false}
+                      name={series.name}
+                    />
+                  ))}
+                  <Line
+                    data={diagonalPoints}
+                    dataKey="tpr"
+                    type="monotone"
+                    strokeDasharray="5 5"
+                    stroke="rgba(255,255,255,0.3)"
+                    dot={false}
+                    isAnimationActive={false}
+                    name="Chance"
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </Box>
+          </Paper>
+        </Grid>
+      </Grid>
+
+      <ModelMetricsComparison models={selectedModels} />
+
+      <PredictionTable
+        predictions={filteredPredictions}
+        models={selectedModels.length ? selectedModels : datasetModels.length ? datasetModels : data.models}
+        selectedModelId={
+          predictionModelId || selectedModels[0]?.id || datasetModels[0]?.id || data.models[0].id
+        }
+        onChangeModel={setPredictionModelId}
+        threshold={threshold}
+        onThresholdChange={setThreshold}
+        onlyMisclassified={onlyMisclassified}
+        onToggleMisclassified={setOnlyMisclassified}
+      />
+    </Box>
+  );
+}

--- a/ml-platform/src/contexts/AppProviders.tsx
+++ b/ml-platform/src/contexts/AppProviders.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+interface AppProvidersProps {
+  children: ReactNode;
+}
+
+export default function AppProviders({ children }: AppProvidersProps) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: 1
+          }
+        }
+      })
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/ml-platform/src/services/mock/performanceData.ts
+++ b/ml-platform/src/services/mock/performanceData.ts
@@ -1,0 +1,201 @@
+import { ModelPerformanceResponse } from '@/types/performance';
+
+const modelPerformanceMock: ModelPerformanceResponse = {
+  models: [
+    {
+      id: 'model-001',
+      name: 'ChurnGuard XGBoost',
+      type: 'Gradient Boosted Trees',
+      version: 'v4.2.1',
+      status: 'deployed',
+      dataset: 'Telco Churn v7',
+      createdAt: '2024-05-10T08:00:00Z',
+      updatedAt: '2024-05-18T14:22:00Z',
+      metrics: {
+        accuracy: 0.934,
+        precision: 0.912,
+        recall: 0.889,
+        f1Score: 0.900,
+        rocAuc: 0.971,
+        logLoss: 0.302
+      }
+    },
+    {
+      id: 'model-002',
+      name: 'Churn Neural Net',
+      type: 'Neural Network',
+      version: 'v2.1.0',
+      status: 'completed',
+      dataset: 'Telco Churn v7',
+      createdAt: '2024-05-01T09:30:00Z',
+      updatedAt: '2024-05-17T20:15:00Z',
+      metrics: {
+        accuracy: 0.918,
+        precision: 0.902,
+        recall: 0.861,
+        f1Score: 0.881,
+        rocAuc: 0.956,
+        logLoss: 0.341
+      }
+    },
+    {
+      id: 'model-003',
+      name: 'Random Forest Baseline',
+      type: 'Random Forest',
+      version: 'v1.4.3',
+      status: 'completed',
+      dataset: 'Telco Churn v7',
+      createdAt: '2024-04-22T11:05:00Z',
+      updatedAt: '2024-05-12T16:40:00Z',
+      metrics: {
+        accuracy: 0.901,
+        precision: 0.876,
+        recall: 0.842,
+        f1Score: 0.858,
+        rocAuc: 0.938,
+        logLoss: 0.412
+      }
+    }
+  ],
+  performanceRuns: [
+    {
+      id: 'run-001',
+      modelId: 'model-001',
+      createdAt: '2024-05-18T14:20:00Z',
+      dataset: 'Telco Churn v7',
+      metrics: {
+        accuracy: 0.934,
+        precision: 0.912,
+        recall: 0.889,
+        f1Score: 0.900,
+        rocAuc: 0.971,
+        logLoss: 0.302
+      },
+      confusionMatrix: {
+        labels: ['Retained', 'Churned'],
+        values: [
+          [812, 34],
+          [48, 302]
+        ]
+      },
+      roc: [
+        { threshold: 0.9, tpr: 0.51, fpr: 0.03 },
+        { threshold: 0.8, tpr: 0.69, fpr: 0.07 },
+        { threshold: 0.7, tpr: 0.81, fpr: 0.11 },
+        { threshold: 0.6, tpr: 0.87, fpr: 0.16 },
+        { threshold: 0.5, tpr: 0.91, fpr: 0.21 },
+        { threshold: 0.4, tpr: 0.95, fpr: 0.28 },
+        { threshold: 0.3, tpr: 0.97, fpr: 0.35 }
+      ]
+    },
+    {
+      id: 'run-002',
+      modelId: 'model-002',
+      createdAt: '2024-05-17T20:10:00Z',
+      dataset: 'Telco Churn v7',
+      metrics: {
+        accuracy: 0.918,
+        precision: 0.902,
+        recall: 0.861,
+        f1Score: 0.881,
+        rocAuc: 0.956,
+        logLoss: 0.341
+      },
+      confusionMatrix: {
+        labels: ['Retained', 'Churned'],
+        values: [
+          [796, 50],
+          [61, 289]
+        ]
+      },
+      roc: [
+        { threshold: 0.9, tpr: 0.44, fpr: 0.04 },
+        { threshold: 0.8, tpr: 0.64, fpr: 0.09 },
+        { threshold: 0.7, tpr: 0.77, fpr: 0.15 },
+        { threshold: 0.6, tpr: 0.84, fpr: 0.2 },
+        { threshold: 0.5, tpr: 0.89, fpr: 0.27 },
+        { threshold: 0.4, tpr: 0.93, fpr: 0.34 },
+        { threshold: 0.3, tpr: 0.96, fpr: 0.41 }
+      ]
+    },
+    {
+      id: 'run-003',
+      modelId: 'model-003',
+      createdAt: '2024-05-12T16:30:00Z',
+      dataset: 'Telco Churn v7',
+      metrics: {
+        accuracy: 0.901,
+        precision: 0.876,
+        recall: 0.842,
+        f1Score: 0.858,
+        rocAuc: 0.938,
+        logLoss: 0.412
+      },
+      confusionMatrix: {
+        labels: ['Retained', 'Churned'],
+        values: [
+          [781, 65],
+          [72, 278]
+        ]
+      },
+      roc: [
+        { threshold: 0.9, tpr: 0.39, fpr: 0.05 },
+        { threshold: 0.8, tpr: 0.57, fpr: 0.1 },
+        { threshold: 0.7, tpr: 0.71, fpr: 0.18 },
+        { threshold: 0.6, tpr: 0.79, fpr: 0.24 },
+        { threshold: 0.5, tpr: 0.84, fpr: 0.31 },
+        { threshold: 0.4, tpr: 0.9, fpr: 0.39 },
+        { threshold: 0.3, tpr: 0.93, fpr: 0.46 }
+      ]
+    }
+  ],
+  predictions: Array.from({ length: 40 }).map((_, index) => {
+    const modelId = index % 3 === 0 ? 'model-001' : index % 3 === 1 ? 'model-002' : 'model-003';
+    const actual = index % 4 === 0 ? 'Churned' : 'Retained';
+    const predicted = index % 5 === 0 ? 'Churned' : actual;
+    return {
+      id: `pred-${index + 1}`,
+      modelId,
+      actual,
+      predicted,
+      probability: Number((Math.random() * 0.4 + 0.5).toFixed(2)),
+      timestamp: new Date(Date.now() - index * 60000).toISOString(),
+      features: {
+        tenureMonths: Math.floor(Math.random() * 24) + 1,
+        monthlyCharges: Number((Math.random() * 80 + 20).toFixed(2)),
+        supportTickets: Math.floor(Math.random() * 5),
+        contractType: index % 2 === 0 ? 'Two year' : 'Month-to-month'
+      }
+    };
+  }),
+  optimizationResults: [
+    {
+      strategy: 'Bayesian Optimization',
+      metric: 'AUC',
+      bestScore: 0.971,
+      bestParams: {
+        learning_rate: 0.08,
+        max_depth: 5,
+        subsample: 0.9,
+        colsample_bytree: 0.85
+      }
+    },
+    {
+      strategy: 'Random Search',
+      metric: 'F1 Score',
+      bestScore: 0.9,
+      bestParams: {
+        n_estimators: 500,
+        max_depth: 7,
+        min_child_weight: 3
+      }
+    }
+  ]
+};
+
+export async function fetchModelPerformance(): Promise<ModelPerformanceResponse> {
+  await new Promise(resolve => setTimeout(resolve, 400));
+  return modelPerformanceMock;
+}
+
+export type { ModelPerformanceResponse };

--- a/ml-platform/src/theme/ThemeRegistry.tsx
+++ b/ml-platform/src/theme/ThemeRegistry.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
 import theme from './index';
-import '@fontsource/inter/variable.css';
+import '@fontsource-variable/inter';
 import '@fontsource/noto-sans/latin.css';
 
 type ThemeRegistryProps = {

--- a/ml-platform/src/theme/ThemeRegistry.tsx
+++ b/ml-platform/src/theme/ThemeRegistry.tsx
@@ -4,9 +4,6 @@ import * as React from 'react';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
 import theme from './index';
-import '@fontsource-variable/inter';
-import '@fontsource/noto-sans/latin.css';
-
 type ThemeRegistryProps = {
   children: React.ReactNode;
 };

--- a/ml-platform/src/theme/ThemeRegistry.tsx
+++ b/ml-platform/src/theme/ThemeRegistry.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import * as React from 'react';
+import { CssBaseline, ThemeProvider } from '@mui/material';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
+import theme from './index';
+import '@fontsource/inter/variable.css';
+import '@fontsource/noto-sans/latin.css';
+
+type ThemeRegistryProps = {
+  children: React.ReactNode;
+};
+
+export default function ThemeRegistry({ children }: ThemeRegistryProps) {
+  return (
+    <AppRouterCacheProvider>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </AppRouterCacheProvider>
+  );
+}

--- a/ml-platform/src/theme/index.ts
+++ b/ml-platform/src/theme/index.ts
@@ -29,7 +29,7 @@ const theme = createTheme({
     }
   },
   typography: {
-    fontFamily: ['Inter', 'Noto Sans', 'sans-serif'].join(','),
+    fontFamily: ['var(--font-inter)', 'var(--font-noto-sans)', 'sans-serif'].join(','),
     h1: { fontWeight: 700 },
     h2: { fontWeight: 700 },
     h3: { fontWeight: 600 },

--- a/ml-platform/src/theme/index.ts
+++ b/ml-platform/src/theme/index.ts
@@ -1,0 +1,78 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#1173d4',
+      light: '#4095f4'
+    },
+    secondary: {
+      main: '#283039'
+    },
+    background: {
+      default: '#111418',
+      paper: '#181C20'
+    },
+    text: {
+      primary: '#ffffff',
+      secondary: '#9dabb9'
+    },
+    success: {
+      main: '#4caf50'
+    },
+    warning: {
+      main: '#ff9800'
+    },
+    error: {
+      main: '#f44336'
+    }
+  },
+  typography: {
+    fontFamily: ['Inter', 'Noto Sans', 'sans-serif'].join(','),
+    h1: { fontWeight: 700 },
+    h2: { fontWeight: 700 },
+    h3: { fontWeight: 600 },
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    subtitle1: { fontWeight: 500 },
+    subtitle2: { fontWeight: 500 }
+  },
+  shape: {
+    borderRadius: 12
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          backgroundColor: '#181C20',
+          borderRadius: 16
+        }
+      }
+    },
+    MuiButton: {
+      defaultProps: {
+        variant: 'contained'
+      },
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          borderRadius: 12,
+          fontWeight: 600
+        }
+      }
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 20,
+          backgroundImage: 'none'
+        }
+      }
+    }
+  }
+});
+
+export default theme;

--- a/ml-platform/src/types/navigation.ts
+++ b/ml-platform/src/types/navigation.ts
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+
+export interface NavItem {
+  title: string;
+  path: string;
+  icon: ReactNode;
+  roles?: string[];
+  badge?: string;
+}
+
+export interface NavSection {
+  title: string;
+  items: NavItem[];
+}

--- a/ml-platform/src/types/performance.ts
+++ b/ml-platform/src/types/performance.ts
@@ -1,0 +1,68 @@
+export interface ModelMetrics {
+  accuracy: number;
+  precision: number;
+  recall: number;
+  f1Score: number;
+  rocAuc: number;
+  logLoss: number;
+  mae?: number;
+  rmse?: number;
+}
+
+export interface ConfusionMatrix {
+  labels: string[];
+  values: number[][];
+}
+
+export interface RocPoint {
+  threshold: number;
+  tpr: number;
+  fpr: number;
+}
+
+export interface PerformanceRun {
+  id: string;
+  modelId: string;
+  metrics: ModelMetrics;
+  confusionMatrix: ConfusionMatrix;
+  roc: RocPoint[];
+  createdAt: string;
+  dataset: string;
+  notes?: string;
+}
+
+export interface ModelSummary {
+  id: string;
+  name: string;
+  type: string;
+  version: string;
+  status: 'training' | 'completed' | 'failed' | 'deployed';
+  metrics: ModelMetrics;
+  dataset: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PredictionRecord {
+  id: string;
+  modelId: string;
+  actual: string;
+  predicted: string;
+  probability: number;
+  features: Record<string, number | string>;
+  timestamp: string;
+}
+
+export interface OptimizationResult {
+  strategy: string;
+  metric: string;
+  bestScore: number;
+  bestParams: Record<string, number | string>;
+}
+
+export interface ModelPerformanceResponse {
+  models: ModelSummary[];
+  performanceRuns: PerformanceRun[];
+  predictions: PredictionRecord[];
+  optimizationResults: OptimizationResult[];
+}

--- a/ml-platform/src/utils/exportUtils.ts
+++ b/ml-platform/src/utils/exportUtils.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { ModelSummary, PredictionRecord } from '@/types/performance';
+
+function downloadFile(content: BlobPart, filename: string, type: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function exportPredictionsToCSV(predictions: PredictionRecord[], filename = 'predictions.csv') {
+  const headers = ['ID', 'Model', 'Actual', 'Predicted', 'Probability', 'Timestamp'];
+  const featureKeys = Array.from(
+    new Set(predictions.flatMap(pred => Object.keys(pred.features ?? {})))
+  );
+  const rows = predictions.map(pred => [
+    pred.id,
+    pred.modelId,
+    pred.actual,
+    pred.predicted,
+    pred.probability.toString(),
+    pred.timestamp,
+    ...featureKeys.map(key => String(pred.features?.[key] ?? ''))
+  ]);
+
+  const csvContent = [headers.concat(featureKeys), ...rows]
+    .map(row => row.map(value => `"${value.replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+
+  downloadFile(csvContent, filename, 'text/csv;charset=utf-8;');
+}
+
+export function exportModelSummaryPdf(models: ModelSummary[], filename = 'model-report.pdf') {
+  const doc = new jsPDF({ orientation: 'landscape' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(18);
+  doc.text('Model Performance Summary', 14, 20);
+  doc.setFontSize(11);
+  doc.setTextColor('#606f7a');
+  doc.text(`Generated: ${new Date().toLocaleString()}`, 14, 28);
+
+  const body = models.map(model => [
+    model.name,
+    model.type,
+    model.version,
+    model.dataset,
+    (model.metrics.accuracy * 100).toFixed(2) + ' %',
+    (model.metrics.precision * 100).toFixed(2) + ' %',
+    (model.metrics.recall * 100).toFixed(2) + ' %',
+    (model.metrics.f1Score * 100).toFixed(2) + ' %',
+    (model.metrics.rocAuc * 100).toFixed(2) + ' %'
+  ]);
+
+  autoTable(doc, {
+    startY: 36,
+    head: [
+      ['Model', 'Type', 'Version', 'Dataset', 'Accuracy', 'Precision', 'Recall', 'F1 Score', 'ROC AUC']
+    ],
+    body,
+    styles: {
+      font: 'Inter',
+      fontSize: 10
+    },
+    headStyles: {
+      fillColor: [17, 115, 212],
+      halign: 'center'
+    },
+    columnStyles: {
+      0: { cellWidth: 40 },
+      1: { cellWidth: 32 },
+      2: { halign: 'center' },
+      3: { cellWidth: 36 },
+      4: { halign: 'center' }
+    }
+  });
+
+  doc.save(filename);
+}

--- a/ml-platform/tsconfig.json
+++ b/ml-platform/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a new Next.js + Material UI frontend in the `ml-platform` folder with global layout, navigation, and theme providers
- deliver the model performance and comparison experience including metrics cards, confusion matrix, ROC curves, prediction drill-down, and export utilities backed by mock data
- add reusable UI helpers, placeholder screens for future sections, and documentation/readme updates

## Testing
- npm install *(fails: 403 Forbidden when resolving @emotion/react from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cd51044bfc833188488ac85716a1f8