### PR TITLE
feat: recreate mlflow pro dashboard layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,17 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Calcium Imaging Analysis Suite"
+      content="Aurora AI Control Center · end-to-end machine learning operations and observability."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Calcium Imaging Analysis Suite</title>
+    <title>Aurora AI Control Center</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,644 @@
+:root {
+  --background: #f5f6fb;
+  --sidebar-bg: #ffffff;
+  --surface: #ffffff;
+  --surface-alt: #f0f2ff;
+  --text-primary: #0f172a;
+  --text-secondary: #64748b;
+  --accent-blue: #5f5cf1;
+  --accent-cyan: #48c8ff;
+  --accent-green: #3ed0a4;
+  --border: #e2e8f0;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text-primary);
+}
+
+button,
+input {
+  font-family: inherit;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 280px;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.sidebar__logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebar__logo-mark {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-cyan));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.sidebar__logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar__logo-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.sidebar__logo-subtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar__nav-item {
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  color: var(--text-secondary);
+  font-size: 15px;
+  text-align: left;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.sidebar__nav-item:hover {
+  background: rgba(95, 92, 241, 0.08);
+  color: var(--text-primary);
+}
+
+.sidebar__nav-item.is-active {
+  background: linear-gradient(120deg, rgba(95, 92, 241, 0.12), rgba(72, 200, 255, 0.08));
+  color: var(--accent-blue);
+  box-shadow: inset 0 0 0 1px rgba(95, 92, 241, 0.1);
+}
+
+.sidebar__status-card {
+  margin-top: auto;
+  background: linear-gradient(140deg, #1f233b, #2f3458);
+  color: #fff;
+  padding: 20px;
+  border-radius: 18px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  box-shadow: var(--shadow);
+}
+
+.sidebar__status-icon {
+  font-size: 22px;
+}
+
+.sidebar__status-content h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.sidebar__status-content p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.app-shell__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 28px 36px 12px;
+}
+
+.header__search {
+  flex: 1;
+  background: #fff;
+  border-radius: 16px;
+  padding: 12px 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.header__search input {
+  border: none;
+  outline: none;
+  flex: 1;
+  font-size: 15px;
+  color: var(--text-primary);
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-left: 24px;
+}
+
+.header__action-btn {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  border: none;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.header__action-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(95, 92, 241, 0.15);
+}
+
+.header__profile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #fff;
+  padding: 8px 16px 8px 10px;
+  border-radius: 18px;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.header__profile-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.header__profile-name {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.header__profile-role {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.header__profile-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-cyan));
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.app-shell__content {
+  padding: 0 36px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.welcome-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 26px;
+  background: linear-gradient(135deg, #5f5cf1, #7f6bff 55%, #48c8ff);
+  color: #fff;
+  padding: 30px;
+  min-height: 220px;
+  box-shadow: var(--shadow);
+}
+
+.welcome-card__bg {
+  position: absolute;
+  inset: 0;
+  background: url('data:image/svg+xml,%3Csvg width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg"%3E%3Cdefs%3E%3ClinearGradient id="g" x1="0%25" y1="0%25" x2="100%25" y2="100%25"%3E%3Cstop stop-color="%23ffffff" stop-opacity="0.15"/%3E%3Cstop stop-color="%23ffffff" stop-opacity="0" offset="1"/%3E%3C/linearGradient%3E%3C/defs%3E%3Ccircle cx="320" cy="60" r="90" fill="url(%23g)"/%3E%3Ccircle cx="60" cy="300" r="120" fill="url(%23g)"/%3E%3Ccircle cx="360" cy="320" r="70" fill="url(%23g)"/%3E%3C/svg%3E') center / cover no-repeat;
+  opacity: 0.8;
+}
+
+.welcome-card__content {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.welcome-card__greeting {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.welcome-card__avatar {
+  width: 70px;
+  height: 70px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.welcome-card__greeting h1 {
+  margin: 0 0 6px;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.welcome-card__greeting p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.welcome-card__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.btn {
+  border: none;
+  border-radius: 16px;
+  padding: 12px 20px;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn--primary {
+  background: rgba(15, 23, 42, 0.92);
+  color: #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+}
+
+.btn--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.22);
+}
+
+.btn--ghost {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.welcome-card__metrics {
+  position: relative;
+  display: flex;
+  gap: 24px;
+  margin-top: 36px;
+}
+
+.welcome-card__metric {
+  backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 18px;
+  padding: 16px 20px;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.welcome-card__metric-label {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.welcome-card__metric-value {
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 24px;
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 26px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel:nth-of-type(1) {
+  grid-column: span 6;
+}
+
+.panel:nth-of-type(2) {
+  grid-column: span 6;
+}
+
+.panel:nth-of-type(3) {
+  grid-column: span 12;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--accent-blue);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.quick-stats {
+  display: flex;
+  gap: 18px;
+}
+
+.quick-stats__item {
+  flex: 1;
+  background: var(--surface-alt);
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quick-stats__item h3 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--text-secondary);
+}
+
+.quick-stats__item p {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.quick-stats__item span {
+  font-size: 13px;
+  color: var(--accent-blue);
+}
+
+.activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.activity-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.activity-list__avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: var(--surface-alt);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.activity-list__details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.activity-list__name {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.activity-list__details p {
+  margin: 2px 0 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.activity-list__time {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.meetings {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.meeting-card {
+  padding: 20px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(95, 92, 241, 0.08), rgba(72, 200, 255, 0.08));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.meeting-card h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.meeting-card p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.meeting-card__avatars {
+  display: flex;
+  gap: 10px;
+}
+
+.meeting-card__avatars span {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--accent-blue);
+  box-shadow: var(--shadow);
+}
+
+.meeting-card--secondary {
+  background: var(--surface-alt);
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.icon {
+  width: 18px;
+  height: 18px;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  background: currentColor;
+  display: inline-block;
+}
+
+.icon-grid { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%235f5cf1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Crect x="3" y="3" width="7" height="7" rx="1.5"/%3E%3Crect x="14" y="3" width="7" height="7" rx="1.5"/%3E%3Crect x="3" y="14" width="7" height="7" rx="1.5"/%3E%3Crect x="14" y="14" width="7" height="7" rx="1.5"/%3E%3C/svg%3E'); }
+.icon-cubes { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M6.5 10.5 12 13l5.5-2.5"/%3E%3Cpath d="m6.5 7.5 5.5 2.5 5.5-2.5L12 5z"/%3E%3Cpath d="m6.5 13.5 5.5 2.5 5.5-2.5"/%3E%3C/svg%3E'); }
+.icon-database { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cellipse cx="12" cy="5" rx="7" ry="3"/%3E%3Cpath d="M19 5v6c0 1.66-3.13 3-7 3s-7-1.34-7-3V5"/%3E%3Cpath d="M5 11v6c0 1.66 3.13 3 7 3s7-1.34 7-3v-6"/%3E%3C/svg%3E'); }
+.icon-flask { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M9 3h6"/%3E%3Cpath d="M10 3v6.13a4 4 0 0 1-.8 2.4L5.6 18.5A2 2 0 0 0 7.2 21h9.6a2 2 0 0 0 1.6-2.5l-3.6-6a4 4 0 0 1-.8-2.4V3"/%3E%3Cpath d="M8.5 10h7"/%3E%3C/svg%3E'); }
+.icon-rocket { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M7 20c0-1.66 2.24-3 5-3s5 1.34 5 3"/%3E%3Cpath d="M12 4 8 14h8l-4-10Z"/%3E%3Cpath d="M12 4 9 2m3 2 3-2"/%3E%3C/svg%3E'); }
+.icon-activity { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M22 12h-4l-3 9L9 3l-3 9H2"/%3E%3C/svg%3E'); }
+.icon-file { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M4 3h8l4 4v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V3Z"/%3E%3Cpath d="M12 3v5h5"/%3E%3C/svg%3E'); }
+.icon-search { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Ccircle cx="11" cy="11" r="7"/%3E%3Cpath d="m20 20-3-3"/%3E%3C/svg%3E'); }
+.icon-bell { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpath d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/%3E%3Cpath d="M13.73 21a2 2 0 0 1-3.46 0"/%3E%3C/svg%3E'); }
+.icon-settings { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3E%3Ccircle cx="12" cy="12" r="3"/%3E%3Cpath d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c0 .69.28 1.35.77 1.83.48.48 1.14.77 1.83.77H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/%3E%3C/svg%3E'); }
+
+@media (max-width: 1200px) {
+  .sidebar {
+    width: 240px;
+  }
+
+  .content-grid {
+    grid-template-columns: repeat(12, 1fr);
+  }
+
+  .panel:nth-of-type(1),
+  .panel:nth-of-type(2) {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+    padding: 20px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    gap: 20px;
+    overflow-x: auto;
+  }
+
+  .sidebar__status-card {
+    display: none;
+  }
+
+  .app-shell__main {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .header__actions {
+    margin-left: 0;
+    justify-content: flex-end;
+  }
+
+  .app-shell__content {
+    padding: 0 20px 32px;
+  }
+
+  .welcome-card {
+    padding: 24px;
+  }
+
+  .welcome-card__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .welcome-card__metrics {
+    flex-direction: column;
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .quick-stats {
+    flex-direction: column;
+  }
+
+  .meeting-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,1354 +1,228 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useDropzone } from 'react-dropzone';
-import { Activity, Upload, Play, Pause, SkipForward, SkipBack, BarChart, FileVideo, FileCheck, Moon, Sun, Palette } from 'lucide-react';
-import axios from 'axios';
-import {
-  Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TablePagination,
-  Paper, Button, FormControl, InputLabel, MenuItem, Select, Switch, FormControlLabel,
-  Slider, Box, Typography, Grid, Accordion, AccordionSummary, AccordionDetails,
-  Tooltip, IconButton, CircularProgress, Autocomplete, TextField, Chip, Snackbar, Alert
-} from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import InfoIcon from '@mui/icons-material/Info';
-import DarkModeIcon from '@mui/icons-material/DarkMode';
-import LightModeIcon from '@mui/icons-material/LightMode';
-import ColorLensIcon from '@mui/icons-material/ColorLens';
+import React from 'react';
+import './App.css';
 
-const API_URL = 'http://localhost:5001';
+const navItems = [
+  { label: 'Dashboard', icon: 'grid' },
+  { label: 'Models', icon: 'cubes' },
+  { label: 'Data', icon: 'database' },
+  { label: 'Experiments', icon: 'flask' },
+  { label: 'Deployments', icon: 'rocket' },
+  { label: 'Monitoring', icon: 'activity' },
+  { label: 'Reports', icon: 'file' }
+];
 
-const api = axios.create({
-  baseURL: API_URL,
-  timeout: 300000,
-  headers: {
-    'Content-Type': 'application/json',
+const projectMetrics = [
+  { label: 'Active Projects', value: '12', accent: '#5f5cf1' },
+  { label: 'Models Training', value: '3', accent: '#48c8ff' },
+  { label: 'Success Rate', value: '94%', accent: '#3ed0a4' }
+];
+
+const quickStats = [
+  { title: 'Active Models', value: '18', delta: '+2 this week' },
+  { title: 'Scheduled Deployments', value: '5', delta: 'Next in 2h 14m' },
+  { title: 'Pending Reviews', value: '3', delta: 'Team feedback needed' }
+];
+
+const activities = [
+  {
+    avatar: 'AC',
+    name: 'Alex Chen',
+    action: 'Deployed "Customer Churn v4" to production',
+    time: '08:24 AM'
+  },
+  {
+    avatar: 'LM',
+    name: 'Lara Martinez',
+    action: 'Reviewed experiment "Image Classifier Sweep"',
+    time: '07:52 AM'
+  },
+  {
+    avatar: 'JW',
+    name: 'Jamie Wong',
+    action: 'Pushed new features to project "Vision Analytics"',
+    time: '07:30 AM'
   }
-});
+];
 
-// Add request interceptor for multipart/form-data
-api.interceptors.request.use(config => {
-  if (config.data instanceof FormData) {
-    config.headers['Content-Type'] = 'multipart/form-data';
-  }
-  return config;
-});
+function Icon({ name }) {
+  return <span className={`icon icon-${name}`} aria-hidden="true" />;
+}
 
-function App() {
-  const [file, setFile] = useState(null);
-  const [maskFile, setMaskFile] = useState(null);
-  const [frames, setFrames] = useState([]);
-  const [currentFrame, setCurrentFrame] = useState(0);
-  const [analyzing, setAnalyzing] = useState(false);
-  const [results, setResults] = useState(null);
-  const [maskPreview, setMaskPreview] = useState(null);
-  const [serverStatus, setServerStatus] = useState('checking');
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [totalFrames, setTotalFrames] = useState(0);
-  const [fps, setFps] = useState(30);
-  const playbackInterval = React.useRef(null);
-  const [csvData, setCsvData] = useState({ rows: [], columns: [] });
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
-  const [uploadedVideoPath, setUploadedVideoPath] = useState(null);
-  const [selectedCells, setSelectedCells] = useState([]);
-  const [plotData, setPlotData] = useState(null);
-  const [plotOptions, setPlotOptions] = useState({
-    y_axis: 'intensity',
-    x_axis: 'frame',
-    style: {
-      theme: 'bw',
-      line_size: 1,
-      show_points: true,
-      point_size: 2,
-      fill_alpha: 0,
-      color_palette: 'Set1',
-      background: null,
-      grid_color: 'grey80',
-      grid_style: 'both',
-      y_scale: 'regular',
-      axis_text_size: 10,
-      legend_position: 'right',
-      smooth_lines: false,
-      smooth_span: 0.75,
-      show_error_bands: false
-    }
-  });
-  const [loading, setLoading] = useState(false);
-  const [maskImage, setMaskImage] = useState(null);
-  const [cellIds, setCellIds] = useState([]);
-  const [maskPath, setMaskPath] = useState(null);
-  const [brightness, setBrightness] = useState(100);
-  const [contrast, setContrast] = useState(100);
-  const [theme, setTheme] = useState('light'); // 'light', 'dark', or 'colorful'
-
-  // Check server status on component mount
-  React.useEffect(() => {
-    checkServerStatus();
-  }, []);
-
-  React.useEffect(() => {
-    if (isPlaying) {
-      playbackInterval.current = setInterval(() => {
-        setCurrentFrame(prev => (prev + 1) % totalFrames);
-      }, 1000 / fps);
-    } else {
-      clearInterval(playbackInterval.current);
-    }
-    return () => clearInterval(playbackInterval.current);
-  }, [isPlaying, totalFrames, fps]);
-
-  const checkServerStatus = React.useCallback(async () => {
-    try {
-      await api.get('/health');
-      setServerStatus('running');
-      setError(null);
-    } catch (error) {
-      console.error('Server status check error:', error);
-      setServerStatus('error');
-      setError('Cannot connect to server. Please ensure the Flask backend is running.');
-    }
-  }, []);
-
-  // Add periodic health check
-  React.useEffect(() => {
-    const interval = setInterval(checkServerStatus, 5000); // Check every 5 seconds
-    return () => clearInterval(interval);
-  }, [checkServerStatus]);
-
-  React.useEffect(() => {
-    if (csvData?.columns?.length > 0) {
-      // Update y_axis if current selection is not available
-      const numericalColumns = csvData.columns.filter(col => 
-        ['intensity', 'normalized_intensity', 'frame'].includes(col)
-      );
-      
-      if (numericalColumns.length > 0 && !numericalColumns.includes(plotOptions.y_axis)) {
-        setPlotOptions(prev => ({
-          ...prev,
-          y_axis: numericalColumns[0]
-        }));
-      }
-    }
-  }, [csvData, plotOptions.y_axis]);
-
-  const onMaskDrop = React.useCallback(async (acceptedFiles) => {
-    if (acceptedFiles.length === 0) return;
-    
-    const file = acceptedFiles[0];
-    console.log('Uploading mask file:', file.name);
-    
-    const formData = new FormData();
-    formData.append('file', file);
-    
-    try {
-      setLoading(true);
-      setError(null);
-      
-      console.log('Sending mask upload request...');
-      const response = await axios.post(`${API_URL}/upload-mask`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
-      
-      console.log('Mask upload response:', response.data);
-      
-      if (response.data.mask_image) {
-        setMaskImage(`data:image/png;base64,${response.data.mask_image}`);
-        setCellIds(response.data.cell_ids || []);
-        setMaskPath(response.data.mask_path);
-        console.log('Mask processed successfully');
-      } else {
-        throw new Error('No mask image in response');
-      }
-    } catch (error) {
-      console.error('Error uploading mask:', error);
-      setError(error.response?.data?.error || 'Error uploading mask');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const MaskDropzone = ({ onMaskUpload }) => {
-    const { getRootProps, getInputProps, isDragActive } = useDropzone({
-      accept: {
-        'image/tiff': ['.tif', '.tiff'],
-      },
-      maxFiles: 1,
-      onDrop: onMaskUpload
-    });
-
-    return (
-      <Box
-        {...getRootProps()}
-        sx={{
-          border: '2px dashed #ccc',
-          borderRadius: 2,
-          p: 2,
-          textAlign: 'center',
-          cursor: 'pointer',
-          mb: 2,
-          '&:hover': {
-            borderColor: 'primary.main',
-            backgroundColor: 'rgba(0, 0, 0, 0.04)'
-          }
-        }}
-      >
-        <input {...getInputProps()} />
-        {isDragActive ? (
-          <Typography>Drop the mask file here...</Typography>
-        ) : (
-          <Typography>Drag and drop a mask file here, or click to select</Typography>
-        )}
-      </Box>
-    );
-  };
-
-  const MaskDisplay = ({ maskImage, cellIds }) => {
-    // Only show this component when not in the side-by-side view
-    if (!maskImage || frames.length > 0) return null;
-    
-    return (
-      <Box sx={{ position: 'relative', mb: 2 }}>
-        <Typography variant="h6" gutterBottom>
-          Cell Mask
-        </Typography>
-        <Box
-          sx={{
-            border: '1px solid #ddd',
-            borderRadius: 1,
-            overflow: 'hidden',
-            position: 'relative'
-          }}
-        >
-          <img
-            src={maskImage}
-            alt="Cell Mask"
-            style={{
-              width: '100%',
-              height: 'auto',
-              display: 'block'
-            }}
-          />
-        </Box>
-        <Typography variant="caption" sx={{ mt: 1, display: 'block' }}>
-          {cellIds.length} cells detected
-        </Typography>
-      </Box>
-    );
-  };
-
-  const VideoDisplay = ({ currentFrame, frameCount, brightness, contrast }) => (
-    <Box sx={{ 
-      width: '100%',  
-      margin: '0 auto',
-      position: 'relative',
-      '& img': {
-        width: '100%',
-        height: 'auto',
-        display: 'block',
-        filter: `brightness(${brightness}%) contrast(${contrast}%)`
-      }
-    }}>
-      <img
-        src={currentFrame}
-        alt={`Frame ${frameCount}`}
-        style={{
-          border: '1px solid #ddd',
-          borderRadius: '4px'
-        }}
-      />
-      <Typography
-        variant="caption"
-        sx={{
-          position: 'absolute',
-          bottom: 8,
-          right: 8,
-          bgcolor: 'rgba(0, 0, 0, 0.6)',
-          color: 'white',
-          padding: '2px 6px',
-          borderRadius: 1
-        }}
-      >
-        Frame: {frameCount}
-      </Typography>
-    </Box>
-  );
-
-  const handleVideoUpload = React.useCallback(async (videoFile) => {
-    setError(null);
-    const formData = new FormData();
-    formData.append('video', videoFile);
-
-    try {
-      console.log('Uploading video file:', videoFile.name);
-      setLoading(true);
-      const response = await api.post('/upload', formData);
-      console.log('Video upload response:', response.data);
-      setUploadedVideoPath(response.data.path);
-      setFrames(response.data.frames);
-      setTotalFrames(response.data.frames.length);
-      setCurrentFrame(0);
-    } catch (error) {
-      console.error('Video upload error:', error);
-      if (!error.response) {
-        setError('Cannot connect to server. Please ensure the Flask backend is running and try again.');
-        checkServerStatus();
-      } else {
-        setError('Error uploading video: ' + (error.response?.data?.error || error.message));
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, [checkServerStatus]);
-
-  const { getRootProps, getInputProps } = useDropzone({
-    accept: {
-      'video/*': ['.mp4', '.avi', '.mov'],
-      'image/tiff': ['.tiff', '.tif']
-    },
-    onDrop: React.useCallback(acceptedFiles => {
-      if (serverStatus !== 'running') {
-        checkServerStatus(); // Recheck server status before showing error
-        setError('Cannot upload: Server is not running. Please wait for the server to start.');
-        return;
-      }
-      const videoFile = acceptedFiles[0];
-      setFile(videoFile);
-      handleVideoUpload(videoFile);
-    }, [serverStatus, handleVideoUpload, checkServerStatus])
-  });
-
-  const handleAnalysis = React.useCallback(async () => {
-    if (!uploadedVideoPath) {
-      setError('Please upload a video first');
-      return;
-    }
-
-    setAnalyzing(true);
-    setError(null);
-
-    try {
-      const response = await api.post('/analyze', {
-        video_path: uploadedVideoPath,
-        mask_path: maskPath || null
-      });
-      
-      setResults(response.data);
-      setMaskPreview(response.data.mask_preview);
-      
-      // Load CSV data
-      if (response.data.results_path) {
-        const csvResponse = await api.get('/get-csv-data', {
-          params: { path: response.data.results_path }
-        });
-        setCsvData({
-          rows: csvResponse.data.data,
-          columns: csvResponse.data.columns
-        });
-      }
-    } catch (error) {
-      console.error('Analysis error:', error);
-      if (!error.response) {
-        setError('Cannot connect to server. Please ensure the Flask backend is running and try again.');
-        checkServerStatus();
-      } else {
-        setError('Error during analysis: ' + (error.response?.data?.error || error.message));
-      }
-    } finally {
-      setAnalyzing(false);
-    }
-  }, [uploadedVideoPath, maskPath, checkServerStatus]);
-
-  const togglePlayback = React.useCallback(() => {
-    setIsPlaying(!isPlaying);
-  }, [isPlaying]);
-
-  const nextFrame = React.useCallback(() => {
-    setCurrentFrame(prev => (prev + 1) % totalFrames);
-  }, [totalFrames]);
-
-  const previousFrame = React.useCallback(() => {
-    setCurrentFrame(prev => (prev - 1 + totalFrames) % totalFrames);
-  }, [totalFrames]);
-
+function Sidebar() {
   return (
-    <div className={`min-h-screen p-8 ${theme === 'dark' ? 'bg-[#1a1e2e] text-white' : theme === 'colorful' ? 'bg-blue-50' : 'bg-gray-100'}`}>
-      <div className="max-w-7xl mx-auto">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold">Calcium Imaging Analysis Suite</h1>
-          <div className="flex space-x-2">
-            <button 
-              onClick={() => setTheme('light')} 
-              className={`p-2 rounded-full ${theme === 'light' ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200'}`}
-              title="Light Theme"
-            >
-              <Sun size={20} />
-            </button>
-            <button 
-              onClick={() => setTheme('dark')} 
-              className={`p-2 rounded-full ${theme === 'dark' ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200'}`}
-              title="Dark Theme"
-            >
-              <Moon size={20} />
-            </button>
-            <button 
-              onClick={() => setTheme('colorful')} 
-              className={`p-2 rounded-full ${theme === 'colorful' ? 'bg-blue-100 text-blue-600' : 'hover:bg-gray-200'}`}
-              title="Colorful Theme"
-            >
-              <Palette size={20} />
-            </button>
+    <aside className="sidebar">
+      <div className="sidebar__logo">
+        <div className="sidebar__logo-mark">ML</div>
+        <div className="sidebar__logo-text">
+          <span className="sidebar__logo-title">MLFlow Pro</span>
+          <span className="sidebar__logo-subtitle">Intelligent ML Platform</span>
+        </div>
+      </div>
+      <nav className="sidebar__nav">
+        {navItems.map(item => (
+          <button key={item.label} className={`sidebar__nav-item ${item.label === 'Dashboard' ? 'is-active' : ''}`}>
+            <Icon name={item.icon} />
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </nav>
+      <div className="sidebar__status-card">
+        <div className="sidebar__status-icon">⚡</div>
+        <div className="sidebar__status-content">
+          <h3>System Health</h3>
+          <p>All services operational</p>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function Header() {
+  return (
+    <header className="header">
+      <div className="header__search">
+        <Icon name="search" />
+        <input type="search" placeholder="Search projects, models, experiments..." />
+      </div>
+      <div className="header__actions">
+        <button className="header__action-btn" aria-label="Notifications">
+          <Icon name="bell" />
+        </button>
+        <button className="header__action-btn" aria-label="Settings">
+          <Icon name="settings" />
+        </button>
+        <div className="header__profile">
+          <div className="header__profile-text">
+            <span className="header__profile-name">Alex Chen</span>
+            <span className="header__profile-role">Data Scientist</span>
+          </div>
+          <div className="header__profile-avatar">AC</div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function WelcomeCard() {
+  return (
+    <section className="welcome-card">
+      <div className="welcome-card__bg" />
+      <div className="welcome-card__content">
+        <div className="welcome-card__greeting">
+          <div className="welcome-card__avatar">AC</div>
+          <div>
+            <h1>Good afternoon, Alex Chen!</h1>
+            <p>Data Scientist · Ready to build something amazing today?</p>
           </div>
         </div>
-        
-        {error && (
-          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-            {error}
-          </div>
-        )}
-        
-        {success && (
-          <Snackbar
-            open={!!success}
-            autoHideDuration={6000}
-            onClose={() => setSuccess(null)}
-          >
-            <Alert severity="success" sx={{ width: '100%' }}>
-              {success}
-            </Alert>
-          </Snackbar>
-        )}
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {/* Video Upload Section */}
-          <div className={`p-6 rounded-lg shadow-md ${theme === 'dark' ? 'bg-[#242a3d]' : 'bg-white'}`}>
-            <h2 className="text-xl font-semibold mb-4">Upload Video</h2>
-            <div {...getRootProps()} className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center cursor-pointer hover:border-blue-500">
-              <input {...getInputProps()} />
-              <FileVideo className="mx-auto mb-2" />
-              <p>Drag & drop a video file here, or click to select</p>
-              <p className="text-sm text-gray-500">Supported formats: .tiff, .tif, .ome.tiff, .mp4, .avi</p>
-            </div>
-            {loading && (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, my: 2 }}>
-                <CircularProgress size={20} />
-                <Typography>Processing video...</Typography>
-              </Box>
-            )}
-          </div>
-
-          {/* Mask Upload Section */}
-          <div className={`p-6 rounded-lg shadow-md ${theme === 'dark' ? 'bg-[#242a3d]' : 'bg-white'}`}>
-            <h2 className="text-xl font-semibold mb-4">Upload Mask</h2>
-            <MaskDropzone onMaskUpload={onMaskDrop} />
-            {loading && (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, my: 2 }}>
-                <CircularProgress size={20} />
-                <Typography>Processing mask...</Typography>
-              </Box>
-            )}
-            <MaskDisplay maskImage={maskImage} cellIds={cellIds} />
-          </div>
+        <div className="welcome-card__actions">
+          <button className="btn btn--primary">New Project</button>
+          <button className="btn btn--ghost">View Tutorials</button>
         </div>
-
-        {/* Video Player Section */}
-        {frames.length > 0 && (
-          <div className={`mt-8 p-6 rounded-lg shadow-md ${theme === 'dark' ? 'bg-[#242a3d]' : 'bg-white'}`}>
-            <h2 className="text-xl font-semibold mb-4">Video and Mask</h2>
-            <div className="flex flex-wrap md:flex-nowrap gap-4">
-              <div className="w-full md:w-1/2">
-                <Typography variant="h6" gutterBottom className={theme === 'dark' ? 'text-gray-200' : ''}>Video</Typography>
-                <VideoDisplay 
-                  currentFrame={`data:image/png;base64,${frames[currentFrame]}`} 
-                  frameCount={currentFrame} 
-                  brightness={brightness} 
-                  contrast={contrast} 
-                />
-                <div className="mb-2">
-                  <Slider
-                    min={0}
-                    max={totalFrames - 1}
-                    value={currentFrame}
-                    onChange={(e, newValue) => setCurrentFrame(parseInt(newValue))}
-                    valueLabelDisplay="auto"
-                    size="small"
-                    sx={{
-                      color: theme === 'dark' ? '#fff' : '#1976d2',
-                      height: 4,
-                      '& .MuiSlider-thumb': {
-                        width: 14,
-                        height: 14,
-                        backgroundColor: '#fff',
-                        '&:hover, &.Mui-focusVisible': {
-                          boxShadow: '0px 0px 0px 8px rgba(255, 255, 255, 0.16)'
-                        }
-                      },
-                      '& .MuiSlider-rail': {
-                        opacity: 0.5,
-                        backgroundColor: theme === 'dark' ? '#4d5566' : '#bfbfbf',
-                      },
-                      '& .MuiSlider-track': {
-                        border: 'none',
-                      }
-                    }}
-                  />
-                </div>
-                
-                {/* Controls in a 2-column grid */}
-                <div className="grid grid-cols-2 gap-x-4 gap-y-2">
-                  {/* Playback Speed */}
-                  <div>
-                    <Typography variant="caption" display="block" className={theme === 'dark' ? 'text-gray-300' : ''}>Speed (FPS)</Typography>
-                    <div className="flex items-center space-x-2">
-                      <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>1</span>
-                      <Slider
-                        min={1}
-                        max={60}
-                        value={fps}
-                        onChange={(e, newValue) => setFps(newValue)}
-                        valueLabelDisplay="auto"
-                        size="small"
-                        sx={{
-                          color: theme === 'dark' ? '#fff' : '#1976d2',
-                          height: 4,
-                          '& .MuiSlider-thumb': {
-                            width: 14,
-                            height: 14,
-                            backgroundColor: '#fff',
-                            '&:hover, &.Mui-focusVisible': {
-                              boxShadow: '0px 0px 0px 8px rgba(255, 255, 255, 0.16)'
-                            }
-                          },
-                          '& .MuiSlider-rail': {
-                            opacity: 0.5,
-                            backgroundColor: theme === 'dark' ? '#4d5566' : '#bfbfbf',
-                          },
-                          '& .MuiSlider-track': {
-                            border: 'none',
-                          }
-                        }}
-                      />
-                      <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>60</span>
-                    </div>
-                  </div>
-                  
-                  {/* Brightness */}
-                  <div>
-                    <Typography variant="caption" display="block" className={theme === 'dark' ? 'text-gray-300' : ''}>Brightness</Typography>
-                    <div className="flex items-center space-x-2">
-                      <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>0%</span>
-                      <Slider
-                        min={0}
-                        max={200}
-                        value={brightness}
-                        onChange={(e, newValue) => setBrightness(newValue)}
-                        valueLabelDisplay="auto"
-                        size="small"
-                        sx={{
-                          color: theme === 'dark' ? '#fff' : '#1976d2',
-                          height: 4,
-                          '& .MuiSlider-thumb': {
-                            width: 14,
-                            height: 14,
-                            backgroundColor: '#fff',
-                            '&:hover, &.Mui-focusVisible': {
-                              boxShadow: '0px 0px 0px 8px rgba(255, 255, 255, 0.16)'
-                            }
-                          },
-                          '& .MuiSlider-rail': {
-                            opacity: 0.5,
-                            backgroundColor: theme === 'dark' ? '#4d5566' : '#bfbfbf',
-                          },
-                          '& .MuiSlider-track': {
-                            border: 'none',
-                          }
-                        }}
-                      />
-                      <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>200%</span>
-                    </div>
-                  </div>
-                  
-                  {/* Contrast */}
-                  <div className="col-span-2">
-                    <Typography variant="caption" display="block" className={theme === 'dark' ? 'text-gray-300' : ''}>Contrast</Typography>
-                    <div className="flex items-center space-x-2">
-                      <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>0%</span>
-                      <Slider
-                        min={0}
-                        max={200}
-                        value={contrast}
-                        onChange={(e, newValue) => setContrast(newValue)}
-                        valueLabelDisplay="auto"
-                        size="small"
-                        sx={{
-                          color: theme === 'dark' ? '#fff' : '#1976d2',
-                          height: 4,
-                          '& .MuiSlider-thumb': {
-                            width: 14,
-                            height: 14,
-                            backgroundColor: '#fff',
-                            '&:hover, &.Mui-focusVisible': {
-                              boxShadow: '0px 0px 0px 8px rgba(255, 255, 255, 0.16)'
-                            }
-                          },
-                          '& .MuiSlider-rail': {
-                            opacity: 0.5,
-                            backgroundColor: theme === 'dark' ? '#4d5566' : '#bfbfbf',
-                          },
-                          '& .MuiSlider-track': {
-                            border: 'none',
-                          }
-                        }}
-                      />
-                      <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>200%</span>
-                    </div>
-                  </div>
-                </div>
-                
-                <div className="flex items-center justify-between mb-2 mt-2">
-                  <div className="flex items-center space-x-2">
-                    <button onClick={previousFrame} className="p-1 rounded-full hover:bg-gray-200">
-                      <SkipBack className="w-5 h-5" />
-                    </button>
-                    <button onClick={togglePlayback} className="p-1 rounded-full hover:bg-gray-200">
-                      {isPlaying ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5" />}
-                    </button>
-                    <button onClick={nextFrame} className="p-1 rounded-full hover:bg-gray-200">
-                      <SkipForward className="w-5 h-5" />
-                    </button>
-                  </div>
-                  <Typography variant="caption">
-                    Frame: {currentFrame + 1}/{totalFrames}
-                  </Typography>
-                </div>
-              </div>
-              
-              <div className="w-full md:w-1/2">
-                <Typography variant="h6" gutterBottom className={theme === 'dark' ? 'text-gray-200' : ''}>Cell Mask</Typography>
-                {maskImage ? (
-                  <>
-                    <Box
-                      sx={{
-                        border: theme === 'dark' ? '1px solid #3a4055' : '1px solid #ddd',
-                        borderRadius: '4px',
-                        overflow: 'hidden'
-                      }}
-                    >
-                      <img
-                        src={maskImage}
-                        alt="Cell Mask"
-                        style={{
-                          width: '100%',
-                          height: 'auto',
-                          display: 'block'
-                        }}
-                      />
-                    </Box>
-                    <Typography variant="caption" sx={{ mt: 1, display: 'block' }}>
-                      {cellIds.length} cells detected
-                    </Typography>
-                  </>
-                ) : (
-                  <Typography color="text.secondary">
-                    No mask uploaded. You can still analyze the video without a mask.
-                  </Typography>
-                )}
-              </div>
-            </div>
-            
-            <div className="mt-6 text-center">
-              <button
-                onClick={handleAnalysis}
-                disabled={analyzing || !uploadedVideoPath}
-                className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {analyzing ? (
-                  <>
-                    <CircularProgress size={20} sx={{ color: 'white', mr: 1 }} />
-                    Analyzing...
-                  </>
-                ) : (
-                  <>Analyze Video</>
-                )}
-              </button>
-            </div>
+      </div>
+      <div className="welcome-card__metrics">
+        {projectMetrics.map(metric => (
+          <div key={metric.label} className="welcome-card__metric">
+            <span className="welcome-card__metric-label">{metric.label}</span>
+            <span className="welcome-card__metric-value" style={{ color: metric.accent }}>
+              {metric.value}
+            </span>
           </div>
-        )}
+        ))}
+      </div>
+    </section>
+  );
+}
 
-        {/* Analysis Results Section */}
-        {results && (
-          <div className={`mt-8 p-6 rounded-lg shadow-md ${theme === 'dark' ? 'bg-[#242a3d]' : 'bg-white'}`}>
-            <h2 className="text-xl font-semibold mb-4">Analysis Results</h2>
-            
-            {/* Cell Selection */}
-            <div className="mb-6">
-              <Typography variant="h6" gutterBottom>Select Cells for Analysis</Typography>
-              <Autocomplete
-                multiple
-                options={cellIds}
-                value={selectedCells}
-                onChange={(event, newValue) => setSelectedCells(newValue)}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    variant="outlined"
-                    label="Select Cells"
-                    placeholder="Choose cells"
-                  />
-                )}
-                renderTags={(value, getTagProps) =>
-                  value.map((option, index) => (
-                    <Chip
-                      label={`Cell ${option}`}
-                      {...getTagProps({ index })}
-                      color="primary"
-                      variant="outlined"
-                    />
-                  ))
-                }
-              />
-            </div>
-
-            {/* Export Buttons */}
-            <div className="flex flex-wrap gap-4 mb-6">
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={() => {
-                  if (selectedCells.length === 0) {
-                    setError('Please select at least one cell to export');
-                    return;
-                  }
-                  setLoading(true);
-                  api.post('/export-csv', { 
-                    cells: selectedCells,
-                    results_path: results.results_path
-                  })
-                  .then(response => {
-                    // Get the file data
-                    return fetch(`${API_URL}/download?path=${encodeURIComponent(response.data.path || response.data.export_path)}`);
-                  })
-                  .then(response => response.blob())
-                  .then(blob => {
-                    // Create a file name with timestamp
-                    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-                    const fileName = `selected_cells_${timestamp}.csv`;
-                    
-                    // Use the File System Access API if available
-                    if ('showSaveFilePicker' in window) {
-                      const opts = {
-                        suggestedName: fileName,
-                        types: [{
-                          description: 'CSV Files',
-                          accept: {'text/csv': ['.csv']},
-                        }],
-                      };
-                      
-                      window.showSaveFilePicker(opts)
-                        .then(fileHandle => fileHandle.createWritable())
-                        .then(writable => {
-                          writable.write(blob);
-                          return writable.close();
-                        })
-                        .then(() => {
-                          setSuccess('File saved successfully!');
-                        })
-                        .catch(err => {
-                          // If user cancels, don't show error
-                          if (err.name !== 'AbortError') {
-                            console.error('Save error:', err);
-                            setError('Error saving file: ' + err.message);
-                            
-                            // Fallback to traditional download
-                            const url = URL.createObjectURL(blob);
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.download = fileName;
-                            document.body.appendChild(a);
-                            a.click();
-                            document.body.removeChild(a);
-                            URL.revokeObjectURL(url);
-                          }
-                        });
-                    } else {
-                      // Fallback for browsers that don't support File System Access API
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement('a');
-                      a.href = url;
-                      a.download = fileName;
-                      document.body.appendChild(a);
-                      a.click();
-                      document.body.removeChild(a);
-                      URL.revokeObjectURL(url);
-                    }
-                  })
-                  .catch(err => {
-                    console.error('Export error:', err);
-                    setError('Error exporting data: ' + (err.response?.data?.error || err.message));
-                  })
-                  .finally(() => setLoading(false));
-                }}
-                disabled={loading || selectedCells.length === 0}
-                startIcon={loading ? <CircularProgress size={20} /> : <FileCheck />}
-              >
-                Export Selected Cells
-              </Button>
-              
-              <Button
-                variant="outlined"
-                color="primary"
-                onClick={() => {
-                  setLoading(true);
-                  api.post('/export-all-csv', { 
-                    path: results.results_path
-                  })
-                  .then(response => {
-                    // Get the file data
-                    return fetch(`${API_URL}/download?path=${encodeURIComponent(response.data.path)}`);
-                  })
-                  .then(response => response.blob())
-                  .then(blob => {
-                    // Create a file name with timestamp
-                    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-                    const fileName = `all_cells_${timestamp}.csv`;
-                    
-                    // Use the File System Access API if available
-                    if ('showSaveFilePicker' in window) {
-                      const opts = {
-                        suggestedName: fileName,
-                        types: [{
-                          description: 'CSV Files',
-                          accept: {'text/csv': ['.csv']},
-                        }],
-                      };
-                      
-                      window.showSaveFilePicker(opts)
-                        .then(fileHandle => fileHandle.createWritable())
-                        .then(writable => {
-                          writable.write(blob);
-                          return writable.close();
-                        })
-                        .then(() => {
-                          setSuccess('File saved successfully!');
-                        })
-                        .catch(err => {
-                          // If user cancels, don't show error
-                          if (err.name !== 'AbortError') {
-                            console.error('Save error:', err);
-                            setError('Error saving file: ' + err.message);
-                            
-                            // Fallback to traditional download
-                            const url = URL.createObjectURL(blob);
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.download = fileName;
-                            document.body.appendChild(a);
-                            a.click();
-                            document.body.removeChild(a);
-                            URL.revokeObjectURL(url);
-                          }
-                        });
-                    } else {
-                      // Fallback for browsers that don't support File System Access API
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement('a');
-                      a.href = url;
-                      a.download = fileName;
-                      document.body.appendChild(a);
-                      a.click();
-                      document.body.removeChild(a);
-                      URL.revokeObjectURL(url);
-                    }
-                  })
-                  .catch(err => {
-                    console.error('Export error:', err);
-                    setError('Error exporting data: ' + (err.response?.data?.error || err.message));
-                  })
-                  .finally(() => setLoading(false));
-                }}
-                disabled={loading}
-                startIcon={loading ? <CircularProgress size={20} /> : <FileCheck />}
-              >
-                Export All Cells
-              </Button>
-            </div>
-
-            {/* Data Visualization Tabs */}
-            <Accordion defaultExpanded>
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h6">Data Table</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                {csvData.rows.length > 0 ? (
-                  <>
-                    <TableContainer component={Paper} sx={{ maxHeight: 440 }}>
-                      <Table stickyHeader size="small">
-                        <TableHead>
-                          <TableRow>
-                            {csvData.columns.map((column) => (
-                              <TableCell key={column}>{column}</TableCell>
-                            ))}
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {csvData.rows
-                            .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                            .map((row, rowIndex) => (
-                              <TableRow key={rowIndex}>
-                                {Object.values(row).map((cell, cellIndex) => (
-                                  <TableCell key={cellIndex}>{cell}</TableCell>
-                                ))}
-                              </TableRow>
-                            ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                    <TablePagination
-                      rowsPerPageOptions={[10, 25, 50, 100]}
-                      component="div"
-                      count={csvData.rows.length}
-                      rowsPerPage={rowsPerPage}
-                      page={page}
-                      onPageChange={(e, newPage) => setPage(newPage)}
-                      onRowsPerPageChange={(e) => {
-                        setRowsPerPage(parseInt(e.target.value, 10));
-                        setPage(0);
-                      }}
-                    />
-                  </>
-                ) : (
-                  <Typography color="text.secondary">No data available</Typography>
-                )}
-              </AccordionDetails>
-            </Accordion>
-
-            {/* Plot Section */}
-            <Accordion defaultExpanded sx={{ mt: 2 }}>
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h6">Intensity Plot</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <div className="flex flex-col md:flex-row gap-4">
-                  <div className="md:w-1/4">
-                    <Typography variant="subtitle1" gutterBottom>Plot Settings</Typography>
-                    
-                    <FormControl fullWidth margin="normal" size="small">
-                      <InputLabel>Y-Axis</InputLabel>
-                      <Select
-                        value={plotOptions.y_axis}
-                        label="Y-Axis"
-                        onChange={(e) => setPlotOptions(prev => ({ ...prev, y_axis: e.target.value }))}
-                      >
-                        <MenuItem value="intensity">Raw Intensity</MenuItem>
-                        <MenuItem value="normalized_intensity">Normalized Intensity</MenuItem>
-                      </Select>
-                    </FormControl>
-                    
-                    <FormControl fullWidth margin="normal" size="small">
-                      <InputLabel>X-Axis</InputLabel>
-                      <Select
-                        value={plotOptions.x_axis}
-                        label="X-Axis"
-                        onChange={(e) => setPlotOptions(prev => ({ ...prev, x_axis: e.target.value }))}
-                      >
-                        <MenuItem value="frame">Frame</MenuItem>
-                      </Select>
-                    </FormControl>
-                    
-                    <Accordion sx={{ mt: 2 }}>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography>Line Options</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <FormControlLabel
-                          control={
-                            <Switch
-                              checked={plotOptions.style.smooth_lines}
-                              onChange={(e) => setPlotOptions(prev => ({
-                                ...prev,
-                                style: {
-                                  ...prev.style,
-                                  smooth_lines: e.target.checked
-                                }
-                              }))}
-                            />
-                          }
-                          label="Smooth Lines"
-                        />
-                        
-                        {plotOptions.style.smooth_lines && (
-                          <FormControl fullWidth margin="normal" size="small">
-                            <Typography variant="caption" gutterBottom>Smoothing Span</Typography>
-                            <Slider
-                              min={0.1}
-                              max={1}
-                              step={0.05}
-                              value={plotOptions.style.smooth_span || 0.75}
-                              onChange={(e, newValue) => setPlotOptions(prev => ({
-                                ...prev,
-                                style: {
-                                  ...prev.style,
-                                  smooth_span: newValue
-                                }
-                              }))}
-                              valueLabelDisplay="auto"
-                              marks={[
-                                { value: 0.1, label: '0.1' },
-                                { value: 0.5, label: '0.5' },
-                                { value: 1, label: '1.0' }
-                              ]}
-                            />
-                          </FormControl>
-                        )}
-                        
-                        <FormControl fullWidth margin="normal" size="small">
-                          <Typography variant="caption" gutterBottom>Line Thickness</Typography>
-                          <Slider
-                            min={0.5}
-                            max={3}
-                            step={0.5}
-                            value={plotOptions.style.line_size || 1}
-                            onChange={(e, newValue) => setPlotOptions(prev => ({
-                              ...prev,
-                              style: {
-                                ...prev.style,
-                                line_size: newValue
-                              }
-                            }))}
-                            valueLabelDisplay="auto"
-                            marks={[
-                              { value: 0.5, label: 'Thin' },
-                              { value: 1.5, label: 'Medium' },
-                              { value: 3, label: 'Thick' }
-                            ]}
-                          />
-                        </FormControl>
-                      </AccordionDetails>
-                    </Accordion>
-                    
-                    <Accordion>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography>Point Options</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <FormControlLabel
-                          control={
-                            <Switch
-                              checked={plotOptions.style.show_points || false}
-                              onChange={(e) => setPlotOptions(prev => ({
-                                ...prev,
-                                style: {
-                                  ...prev.style,
-                                  show_points: e.target.checked
-                                }
-                              }))}
-                            />
-                          }
-                          label="Show Data Points"
-                        />
-                        
-                        {plotOptions.style.show_points && (
-                          <FormControl fullWidth margin="normal" size="small">
-                            <Typography variant="caption" gutterBottom>Point Size</Typography>
-                            <Slider
-                              min={1}
-                              max={5}
-                              step={0.5}
-                              value={plotOptions.style.point_size || 2}
-                              onChange={(e, newValue) => setPlotOptions(prev => ({
-                                ...prev,
-                                style: {
-                                  ...prev.style,
-                                  point_size: newValue
-                                }
-                              }))}
-                              valueLabelDisplay="auto"
-                              marks={[
-                                { value: 1, label: 'Small' },
-                                { value: 3, label: 'Medium' },
-                                { value: 5, label: 'Large' }
-                              ]}
-                            />
-                          </FormControl>
-                        )}
-                      </AccordionDetails>
-                    </Accordion>
-                    
-                    <Accordion>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography>Color Options</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <FormControl fullWidth margin="normal" size="small">
-                          <InputLabel>Color Palette</InputLabel>
-                          <Select
-                            value={plotOptions.style.color_palette || 'Set1'}
-                            label="Color Palette"
-                            onChange={(e) => setPlotOptions(prev => ({
-                              ...prev,
-                              style: {
-                                ...prev.style,
-                                color_palette: e.target.value
-                              }
-                            }))}
-                          >
-                            <MenuItem value="Set1">Set1 (Default)</MenuItem>
-                            <MenuItem value="Set2">Set2</MenuItem>
-                            <MenuItem value="Set3">Set3</MenuItem>
-                            <MenuItem value="Dark2">Dark2</MenuItem>
-                            <MenuItem value="Paired">Paired</MenuItem>
-                            <MenuItem value="Spectral">Spectral</MenuItem>
-                            <MenuItem value="RdYlBu">Red-Yellow-Blue</MenuItem>
-                          </Select>
-                        </FormControl>
-                      </AccordionDetails>
-                    </Accordion>
-                    
-                    <Accordion>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography>Grid & Theme</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <FormControl fullWidth margin="normal" size="small">
-                          <InputLabel>Theme</InputLabel>
-                          <Select
-                            value={plotOptions.style.theme || 'minimal'}
-                            label="Theme"
-                            onChange={(e) => setPlotOptions(prev => ({
-                              ...prev,
-                              style: {
-                                ...prev.style,
-                                theme: e.target.value
-                              }
-                            }))}
-                          >
-                            <MenuItem value="minimal">Minimal</MenuItem>
-                            <MenuItem value="classic">Classic</MenuItem>
-                            <MenuItem value="bw">Black & White</MenuItem>
-                            <MenuItem value="light">Light</MenuItem>
-                            <MenuItem value="dark">Dark</MenuItem>
-                          </Select>
-                        </FormControl>
-                        
-                        <FormControl fullWidth margin="normal" size="small">
-                          <InputLabel>Grid Style</InputLabel>
-                          <Select
-                            value={plotOptions.style.grid_style || 'both'}
-                            label="Grid Style"
-                            onChange={(e) => setPlotOptions(prev => ({
-                              ...prev,
-                              style: {
-                                ...prev.style,
-                                grid_style: e.target.value
-                              }
-                            }))}
-                          >
-                            <MenuItem value="both">Major & Minor</MenuItem>
-                            <MenuItem value="major">Major Only</MenuItem>
-                            <MenuItem value="none">No Grid</MenuItem>
-                          </Select>
-                        </FormControl>
-                        
-                        <FormControl fullWidth margin="normal" size="small">
-                          <InputLabel>Legend Position</InputLabel>
-                          <Select
-                            value={plotOptions.style.legend_position || 'right'}
-                            label="Legend Position"
-                            onChange={(e) => setPlotOptions(prev => ({
-                              ...prev,
-                              style: {
-                                ...prev.style,
-                                legend_position: e.target.value
-                              }
-                            }))}
-                          >
-                            <MenuItem value="right">Right</MenuItem>
-                            <MenuItem value="left">Left</MenuItem>
-                            <MenuItem value="top">Top</MenuItem>
-                            <MenuItem value="bottom">Bottom</MenuItem>
-                            <MenuItem value="none">None</MenuItem>
-                          </Select>
-                        </FormControl>
-                      </AccordionDetails>
-                    </Accordion>
-                    
-                    <Button
-                      variant="contained"
-                      color="primary"
-                      fullWidth
-                      sx={{ mt: 2 }}
-                      onClick={() => {
-                        if (selectedCells.length === 0) {
-                          setError('Please select at least one cell to plot');
-                          return;
-                        }
-                        setLoading(true);
-                        api.post('/generate-plot', {
-                          cells: selectedCells,
-                          path: results.results_path,
-                          options: plotOptions
-                        })
-                        .then(response => {
-                          setPlotData(`data:image/png;base64,${response.data.plot_image}`);
-                        })
-                        .catch(err => {
-                          console.error('Plot generation error:', err);
-                          setError('Error generating plot: ' + (err.response?.data?.error || err.message));
-                        })
-                        .finally(() => setLoading(false));
-                      }}
-                      disabled={loading || selectedCells.length === 0}
-                    >
-                      Generate Plot
-                    </Button>
-                    
-                    {plotData && (
-                      <Button
-                        variant="outlined"
-                        color="primary"
-                        fullWidth
-                        sx={{ mt: 1 }}
-                        onClick={() => {
-                          // Get the image data from the plot
-                          fetch(plotData)
-                            .then(response => response.blob())
-                            .then(blob => {
-                              // Create a file name with timestamp
-                              const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-                              const fileName = `intensity_plot_${timestamp}.png`;
-                              
-                              // Use the File System Access API if available
-                              if ('showSaveFilePicker' in window) {
-                                const opts = {
-                                  suggestedName: fileName,
-                                  types: [{
-                                    description: 'PNG Images',
-                                    accept: {'image/png': ['.png']},
-                                  }],
-                                };
-                                
-                                window.showSaveFilePicker(opts)
-                                  .then(fileHandle => fileHandle.createWritable())
-                                  .then(writable => {
-                                    writable.write(blob);
-                                    return writable.close();
-                                  })
-                                  .then(() => {
-                                    setSuccess('Plot saved successfully!');
-                                  })
-                                  .catch(err => {
-                                    // If user cancels, don't show error
-                                    if (err.name !== 'AbortError') {
-                                      console.error('Save error:', err);
-                                      setError('Error saving plot: ' + err.message);
-                                      
-                                      // Fallback to traditional download
-                                      const url = URL.createObjectURL(blob);
-                                      const a = document.createElement('a');
-                                      a.href = url;
-                                      a.download = fileName;
-                                      document.body.appendChild(a);
-                                      a.click();
-                                      document.body.removeChild(a);
-                                      URL.revokeObjectURL(url);
-                                    }
-                                  });
-                              } else {
-                                // Fallback for browsers that don't support File System Access API
-                                const url = URL.createObjectURL(blob);
-                                const a = document.createElement('a');
-                                a.href = url;
-                                a.download = fileName;
-                                document.body.appendChild(a);
-                                a.click();
-                                document.body.removeChild(a);
-                                URL.revokeObjectURL(url);
-                              }
-                            })
-                            .catch(err => {
-                              console.error('Plot save error:', err);
-                              setError('Error saving plot: ' + err.message);
-                            });
-                        }}
-                      >
-                        Save Plot
-                      </Button>
-                    )}
-                  </div>
-                  
-                  <div className="md:w-3/4">
-                    {plotData ? (
-                      <Box sx={{ 
-                        border: '1px solid #ddd', 
-                        borderRadius: 1, 
-                        p: 1,
-                        bgcolor: '#f9f9f9'
-                      }}>
-                        <img 
-                          src={plotData} 
-                          alt="Intensity Plot" 
-                          style={{ width: '100%', height: 'auto' }}
-                        />
-                      </Box>
-                    ) : (
-                      <Box sx={{ 
-                        display: 'flex', 
-                        alignItems: 'center', 
-                        justifyContent: 'center',
-                        border: '1px dashed #ccc',
-                        borderRadius: 1,
-                        p: 4,
-                        minHeight: 300
-                      }}>
-                        <Typography color="text.secondary">
-                          {selectedCells.length === 0 
-                            ? 'Select cells and click "Generate Plot" to visualize intensity data' 
-                            : 'Click "Generate Plot" to visualize selected cells'}
-                        </Typography>
-                      </Box>
-                    )}
-                  </div>
-                </div>
-              </AccordionDetails>
-            </Accordion>
-            
-            {/* Summary Statistics */}
-            <Accordion sx={{ mt: 2 }}>
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h6">Summary Statistics</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                {results.stats ? (
-                  <TableContainer component={Paper}>
-                    <Table size="small">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>Metric</TableCell>
-                          <TableCell>Value</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {Object.entries(results.stats).map(([key, value]) => (
-                          <TableRow key={key}>
-                            <TableCell>{key.replace(/_/g, ' ')}</TableCell>
-                            <TableCell>{typeof value === 'number' ? value.toFixed(4) : value}</TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                ) : (
-                  <Typography color="text.secondary">No statistics available</Typography>
-                )}
-              </AccordionDetails>
-            </Accordion>
+function QuickStats() {
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <h2>Today&apos;s Overview</h2>
+        <button className="link-button">View analytics</button>
+      </header>
+      <div className="quick-stats">
+        {quickStats.map(stat => (
+          <div key={stat.title} className="quick-stats__item">
+            <h3>{stat.title}</h3>
+            <p>{stat.value}</p>
+            <span>{stat.delta}</span>
           </div>
-        )}
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ActivityFeed() {
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <h2>Recent Activity</h2>
+        <button className="link-button">View all</button>
+      </header>
+      <ul className="activity-list">
+        {activities.map(item => (
+          <li key={item.action} className="activity-list__item">
+            <div className="activity-list__avatar">{item.avatar}</div>
+            <div className="activity-list__details">
+              <span className="activity-list__name">{item.name}</span>
+              <p>{item.action}</p>
+            </div>
+            <span className="activity-list__time">{item.time}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function UpcomingMeetings() {
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <h2>Upcoming Meetings</h2>
+        <button className="link-button">Join next</button>
+      </header>
+      <div className="meetings">
+        <article className="meeting-card">
+          <div>
+            <h3>Weekly Model Review</h3>
+            <p>Today · 3:00 PM · Conference Room B</p>
+          </div>
+          <div className="meeting-card__avatars">
+            <span>AC</span>
+            <span>LM</span>
+            <span>JW</span>
+          </div>
+        </article>
+        <article className="meeting-card meeting-card--secondary">
+          <div>
+            <h3>Deployment Stand-up</h3>
+            <p>Tomorrow · 9:30 AM · Zoom</p>
+          </div>
+          <button className="btn btn--ghost">Add to calendar</button>
+        </article>
+      </div>
+    </section>
+  );
+}
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <Sidebar />
+      <div className="app-shell__main">
+        <Header />
+        <main className="app-shell__content">
+          <WelcomeCard />
+          <div className="content-grid">
+            <QuickStats />
+            <ActivityFeed />
+            <UpcomingMeetings />
+          </div>
+        </main>
       </div>
     </div>
   );
 }
-
-export default App;

--- a/src/components/common/ComingSoon.js
+++ b/src/components/common/ComingSoon.js
@@ -1,0 +1,28 @@
+import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
+import { Paper, Typography } from '@mui/material';
+
+export default function ComingSoon({ title, description }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        px: { xs: 3, md: 6 },
+        py: { xs: 4, md: 6 },
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: 2,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <AccessTimeOutlinedIcon sx={{ fontSize: 48, color: 'primary.light' }} />
+      <Typography variant="h5" fontWeight={600} color="text.primary">
+        {title}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" maxWidth={480}>
+        {description}
+      </Typography>
+    </Paper>
+  );
+}

--- a/src/components/common/MetricCard.js
+++ b/src/components/common/MetricCard.js
@@ -1,0 +1,88 @@
+import { alpha, Box, Chip, LinearProgress, Paper, Stack, Typography } from '@mui/material';
+
+const trendCopy = {
+  up: 'increase',
+  down: 'decrease',
+  stable: 'no change'
+};
+
+export default function MetricCard({
+  title,
+  value,
+  subtitle,
+  icon,
+  trend = 'stable',
+  trendValue,
+  progress,
+  color = 'primary'
+}) {
+  const showTrend = Boolean(trendValue);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={2}>
+        {icon && (
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: theme => alpha(theme.palette[color].main, 0.16),
+              color: `${color}.main`
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        <Box>
+          <Typography variant="overline" color="text.secondary" letterSpacing={0.6}>
+            {title}
+          </Typography>
+          <Typography variant="h5" fontWeight={700} color="text.primary">
+            {value}
+          </Typography>
+          {subtitle && (
+            <Typography variant="body2" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+      </Stack>
+      {progress !== undefined && (
+        <Box>
+          <LinearProgress
+            variant="determinate"
+            value={progress}
+            sx={{
+              height: 6,
+              borderRadius: 999,
+              backgroundColor: 'rgba(255,255,255,0.08)'
+            }}
+            color={color}
+          />
+        </Box>
+      )}
+      {showTrend && (
+        <Chip
+          size="small"
+          color={trend === 'down' ? 'error' : trend === 'up' ? 'success' : 'default'}
+          label={`${trendValue} ${trendCopy[trend]}`}
+          sx={{ alignSelf: 'flex-start' }}
+        />
+      )}
+    </Paper>
+  );
+}

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -1,0 +1,35 @@
+import { Box } from '@mui/material';
+import { useState } from 'react';
+import Sidebar, { drawerWidth } from './Sidebar';
+import Header from './Header';
+import Breadcrumbs from './Breadcrumbs';
+import { useNavigation } from '../../contexts/NavigationContext';
+
+export default function AppLayout({ children }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const { navigate } = useNavigation();
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', backgroundColor: 'background.default' }}>
+      <Sidebar open={mobileOpen} onClose={() => setMobileOpen(false)} onNavigate={navigate} />
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          ml: { lg: `${drawerWidth}px` },
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh'
+        }}
+      >
+        <Header onMenuClick={() => setMobileOpen(true)} />
+        <Box component="section" sx={{ px: { xs: 2, md: 4 }, py: 3, flexGrow: 1 }}>
+          <Breadcrumbs />
+          <Box mt={3} display="flex" flexDirection="column" gap={3}>
+            {children}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/layout/Breadcrumbs.js
+++ b/src/components/layout/Breadcrumbs.js
@@ -1,0 +1,57 @@
+import { Breadcrumbs as MuiBreadcrumbs, Link, Typography } from '@mui/material';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { useNavigation } from '../../contexts/NavigationContext';
+
+function formatSegment(segment) {
+  return segment
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export default function Breadcrumbs() {
+  const { path, navigate } = useNavigation();
+  const segments = path.split('/').filter(Boolean);
+
+  return (
+    <MuiBreadcrumbs
+      separator={<NavigateNextIcon fontSize="small" sx={{ color: 'text.disabled' }} />}
+      aria-label="breadcrumb"
+      sx={{ color: 'text.secondary', fontSize: 14 }}
+    >
+      <Link
+        component="button"
+        type="button"
+        onClick={() => navigate('/dashboard')}
+        color="text.secondary"
+        underline="hover"
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5, font: 'inherit' }}
+      >
+        <HomeOutlinedIcon sx={{ fontSize: 18 }} />
+        Home
+      </Link>
+      {segments.map((segment, index) => {
+        const href = `/${segments.slice(0, index + 1).join('/')}`;
+        const isLast = index === segments.length - 1;
+        return isLast ? (
+          <Typography key={href} color="text.primary" fontWeight={600} fontSize={14}>
+            {formatSegment(segment)}
+          </Typography>
+        ) : (
+          <Link
+            key={href}
+            component="button"
+            type="button"
+            onClick={() => navigate(href)}
+            color="text.secondary"
+            underline="hover"
+            sx={{ fontSize: 14, font: 'inherit' }}
+          >
+            {formatSegment(segment)}
+          </Link>
+        );
+      })}
+    </MuiBreadcrumbs>
+  );
+}

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,0 +1,87 @@
+import {
+  alpha,
+  Avatar,
+  Badge,
+  Box,
+  IconButton,
+  InputBase,
+  Stack,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import SearchIcon from '@mui/icons-material/Search';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+
+export default function Header({ onMenuClick }) {
+  return (
+    <Box
+      component="header"
+      sx={{
+        height: 72,
+        display: 'flex',
+        alignItems: 'center',
+        px: 3,
+        gap: 3,
+        backdropFilter: 'blur(12px)',
+        backgroundColor: alpha('#111418', 0.85),
+        borderBottom: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <IconButton onClick={onMenuClick} sx={{ display: { lg: 'none' } }} color="inherit">
+        <MenuIcon />
+      </IconButton>
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          backgroundColor: alpha('#ffffff', 0.04),
+          px: 2,
+          py: 1,
+          borderRadius: 2
+        }}
+      >
+        <SearchIcon sx={{ color: 'text.secondary' }} />
+        <InputBase
+          placeholder="Search projects, models, datasets..."
+          sx={{ flex: 1, color: 'text.primary' }}
+          inputProps={{ 'aria-label': 'search' }}
+        />
+      </Box>
+      <Stack direction="row" alignItems="center" spacing={1.5}>
+        <Tooltip title="Support">
+          <IconButton color="inherit">
+            <HelpOutlineOutlinedIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Notifications">
+          <IconButton color="inherit">
+            <Badge color="error" variant="dot" overlap="circular">
+              <NotificationsNoneOutlinedIcon />
+            </Badge>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Settings">
+          <IconButton color="inherit">
+            <SettingsOutlinedIcon />
+          </IconButton>
+        </Tooltip>
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+          <Box textAlign="right">
+            <Typography variant="subtitle2" color="text.primary">
+              Jordan Williams
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Lead ML Engineer
+            </Typography>
+          </Box>
+          <Avatar src="https://i.pravatar.cc/100?img=5" alt="Jordan Williams" />
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -1,0 +1,142 @@
+import {
+  Box,
+  Chip,
+  Divider,
+  Drawer,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Typography
+} from '@mui/material';
+import { navSections } from '../../data/navigation';
+import { useNavigation } from '../../contexts/NavigationContext';
+
+export const drawerWidth = 288;
+
+function SidebarContent({ onNavigate }) {
+  const { path } = useNavigation();
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: 'background.default'
+      }}
+    >
+      <Box px={3} py={4} display="flex" flexDirection="column" gap={1}>
+        <Typography variant="subtitle2" color="text.secondary">
+          ML Platform
+        </Typography>
+        <Typography variant="h5" fontWeight={700} color="text.primary">
+          Aurora AI Control Center
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          End-to-end machine learning lifecycle management
+        </Typography>
+      </Box>
+      <Divider sx={{ borderColor: 'divider', opacity: 0.2 }} />
+      <Box flex={1} overflow="auto">
+        {navSections.map(section => (
+          <List
+            key={section.title}
+            subheader={
+              <ListSubheader
+                component="div"
+                disableSticky
+                sx={{
+                  background: 'transparent',
+                  color: 'text.secondary',
+                  fontWeight: 600,
+                  letterSpacing: 0.5
+                }}
+              >
+                {section.title}
+              </ListSubheader>
+            }
+            sx={{
+              '& .MuiListItemButton-root': {
+                borderRadius: 2,
+                mx: 1,
+                mb: 0.5
+              }
+            }}
+          >
+            {section.items.map(item => {
+              const isActive = path.startsWith(item.path);
+              return (
+                <ListItemButton
+                  key={item.title}
+                  onClick={() => onNavigate(item.path)}
+                  selected={isActive}
+                  sx={{
+                    color: isActive ? 'primary.contrastText' : 'text.secondary',
+                    bgcolor: isActive ? 'primary.main' : 'transparent'
+                  }}
+                >
+                  <ListItemIcon sx={{ color: isActive ? 'primary.contrastText' : 'text.secondary' }}>
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={item.title}
+                    primaryTypographyProps={{ fontWeight: isActive ? 600 : 500 }}
+                  />
+                  {item.badge && (
+                    <Chip size="small" color="secondary" label={item.badge} sx={{ ml: 1 }} />
+                  )}
+                </ListItemButton>
+              );
+            })}
+          </List>
+        ))}
+      </Box>
+      <Box px={3} py={3}>
+        <Typography variant="caption" color="text.secondary">
+          Aurora AI Platform © {new Date().getFullYear()}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+export default function Sidebar({ open, onClose, onNavigate }) {
+  return (
+    <>
+      <Drawer
+        variant="temporary"
+        open={open}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: 'block', lg: 'none' },
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box'
+          }
+        }}
+      >
+        <SidebarContent onNavigate={path => {
+          onNavigate(path);
+          onClose();
+        }} />
+      </Drawer>
+      <Drawer
+        variant="permanent"
+        open
+        sx={{
+          display: { xs: 'none', lg: 'block' },
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+            borderRight: '1px solid rgba(255,255,255,0.08)'
+          }
+        }}
+      >
+        <SidebarContent onNavigate={onNavigate} />
+      </Drawer>
+    </>
+  );
+}

--- a/src/contexts/NavigationContext.js
+++ b/src/contexts/NavigationContext.js
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+
+export const NavigationContext = createContext({
+  path: '/dashboard',
+  navigate: () => {}
+});
+
+export function useNavigation() {
+  return useContext(NavigationContext);
+}

--- a/src/data/navigation.js
+++ b/src/data/navigation.js
@@ -1,0 +1,47 @@
+import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined';
+import CloudUploadOutlinedIcon from '@mui/icons-material/CloudUploadOutlined';
+import InsightsOutlinedIcon from '@mui/icons-material/InsightsOutlined';
+import ScatterPlotOutlinedIcon from '@mui/icons-material/ScatterPlotOutlined';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import LeaderboardOutlinedIcon from '@mui/icons-material/LeaderboardOutlined';
+import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
+import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
+import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import SettingsSuggestOutlinedIcon from '@mui/icons-material/SettingsSuggestOutlined';
+
+export const navSections = [
+  {
+    title: 'Overview',
+    items: [
+      { title: 'Dashboard', path: '/dashboard', icon: <DashboardOutlinedIcon /> },
+      { title: 'Data Upload', path: '/data/upload', icon: <CloudUploadOutlinedIcon /> },
+      { title: 'Exploration & EDA', path: '/data/exploration', icon: <InsightsOutlinedIcon /> },
+      { title: 'Dataset Splits', path: '/data/splitting', icon: <ScatterPlotOutlinedIcon /> }
+    ]
+  },
+  {
+    title: 'Models',
+    items: [
+      { title: 'Model Training', path: '/models/training', icon: <ScienceOutlinedIcon /> },
+      { title: 'Hyperparameter Optimization', path: '/models/optimization', icon: <TuneOutlinedIcon /> },
+      {
+        title: 'Performance & Comparison',
+        path: '/models/performance',
+        icon: <LeaderboardOutlinedIcon />,
+        badge: 'New'
+      },
+      { title: 'Interpretability', path: '/models/interpretability', icon: <LightbulbOutlinedIcon /> }
+    ]
+  },
+  {
+    title: 'Operations',
+    items: [
+      { title: 'Deployments', path: '/deployments', icon: <CloudOutlinedIcon /> },
+      { title: 'Projects', path: '/projects', icon: <GroupOutlinedIcon /> },
+      { title: 'Experiment Tracking', path: '/experiments', icon: <AssessmentOutlinedIcon /> },
+      { title: 'Workflows', path: '/workflows', icon: <SettingsSuggestOutlinedIcon /> }
+    ]
+  }
+];

--- a/src/data/performanceData.js
+++ b/src/data/performanceData.js
@@ -1,0 +1,197 @@
+const modelPerformanceMock = {
+  models: [
+    {
+      id: 'model-001',
+      name: 'ChurnGuard XGBoost',
+      type: 'Gradient Boosted Trees',
+      version: 'v4.2.1',
+      status: 'deployed',
+      dataset: 'Telco Churn v7',
+      createdAt: '2024-05-10T08:00:00Z',
+      updatedAt: '2024-05-18T14:22:00Z',
+      metrics: {
+        accuracy: 0.934,
+        precision: 0.912,
+        recall: 0.889,
+        f1Score: 0.9,
+        rocAuc: 0.971,
+        logLoss: 0.302
+      }
+    },
+    {
+      id: 'model-002',
+      name: 'Churn Neural Net',
+      type: 'Neural Network',
+      version: 'v2.1.0',
+      status: 'completed',
+      dataset: 'Telco Churn v7',
+      createdAt: '2024-05-01T09:30:00Z',
+      updatedAt: '2024-05-17T20:15:00Z',
+      metrics: {
+        accuracy: 0.918,
+        precision: 0.902,
+        recall: 0.861,
+        f1Score: 0.881,
+        rocAuc: 0.956,
+        logLoss: 0.341
+      }
+    },
+    {
+      id: 'model-003',
+      name: 'Random Forest Baseline',
+      type: 'Random Forest',
+      version: 'v1.4.3',
+      status: 'completed',
+      dataset: 'Telco Churn v7',
+      createdAt: '2024-04-22T11:05:00Z',
+      updatedAt: '2024-05-12T16:40:00Z',
+      metrics: {
+        accuracy: 0.901,
+        precision: 0.876,
+        recall: 0.842,
+        f1Score: 0.858,
+        rocAuc: 0.938,
+        logLoss: 0.412
+      }
+    }
+  ],
+  performanceRuns: [
+    {
+      id: 'run-001',
+      modelId: 'model-001',
+      createdAt: '2024-05-18T14:20:00Z',
+      dataset: 'Telco Churn v7',
+      metrics: {
+        accuracy: 0.934,
+        precision: 0.912,
+        recall: 0.889,
+        f1Score: 0.9,
+        rocAuc: 0.971,
+        logLoss: 0.302
+      },
+      confusionMatrix: {
+        labels: ['Retained', 'Churned'],
+        values: [
+          [812, 34],
+          [48, 302]
+        ]
+      },
+      roc: [
+        { threshold: 0.9, tpr: 0.51, fpr: 0.03 },
+        { threshold: 0.8, tpr: 0.69, fpr: 0.07 },
+        { threshold: 0.7, tpr: 0.81, fpr: 0.11 },
+        { threshold: 0.6, tpr: 0.87, fpr: 0.16 },
+        { threshold: 0.5, tpr: 0.91, fpr: 0.21 },
+        { threshold: 0.4, tpr: 0.95, fpr: 0.28 },
+        { threshold: 0.3, tpr: 0.97, fpr: 0.35 }
+      ]
+    },
+    {
+      id: 'run-002',
+      modelId: 'model-002',
+      createdAt: '2024-05-17T20:10:00Z',
+      dataset: 'Telco Churn v7',
+      metrics: {
+        accuracy: 0.918,
+        precision: 0.902,
+        recall: 0.861,
+        f1Score: 0.881,
+        rocAuc: 0.956,
+        logLoss: 0.341
+      },
+      confusionMatrix: {
+        labels: ['Retained', 'Churned'],
+        values: [
+          [796, 50],
+          [61, 289]
+        ]
+      },
+      roc: [
+        { threshold: 0.9, tpr: 0.44, fpr: 0.04 },
+        { threshold: 0.8, tpr: 0.64, fpr: 0.09 },
+        { threshold: 0.7, tpr: 0.77, fpr: 0.15 },
+        { threshold: 0.6, tpr: 0.84, fpr: 0.2 },
+        { threshold: 0.5, tpr: 0.89, fpr: 0.27 },
+        { threshold: 0.4, tpr: 0.93, fpr: 0.34 },
+        { threshold: 0.3, tpr: 0.96, fpr: 0.41 }
+      ]
+    },
+    {
+      id: 'run-003',
+      modelId: 'model-003',
+      createdAt: '2024-05-12T16:30:00Z',
+      dataset: 'Telco Churn v7',
+      metrics: {
+        accuracy: 0.901,
+        precision: 0.876,
+        recall: 0.842,
+        f1Score: 0.858,
+        rocAuc: 0.938,
+        logLoss: 0.412
+      },
+      confusionMatrix: {
+        labels: ['Retained', 'Churned'],
+        values: [
+          [781, 65],
+          [72, 278]
+        ]
+      },
+      roc: [
+        { threshold: 0.9, tpr: 0.39, fpr: 0.05 },
+        { threshold: 0.8, tpr: 0.57, fpr: 0.1 },
+        { threshold: 0.7, tpr: 0.71, fpr: 0.18 },
+        { threshold: 0.6, tpr: 0.79, fpr: 0.24 },
+        { threshold: 0.5, tpr: 0.84, fpr: 0.31 },
+        { threshold: 0.4, tpr: 0.9, fpr: 0.39 },
+        { threshold: 0.3, tpr: 0.93, fpr: 0.46 }
+      ]
+    }
+  ],
+  predictions: Array.from({ length: 40 }).map((_, index) => {
+    const modelId = index % 3 === 0 ? 'model-001' : index % 3 === 1 ? 'model-002' : 'model-003';
+    const actual = index % 4 === 0 ? 'Churned' : 'Retained';
+    const predicted = index % 5 === 0 ? 'Churned' : actual;
+    return {
+      id: `pred-${index + 1}`,
+      modelId,
+      actual,
+      predicted,
+      probability: Number((Math.random() * 0.4 + 0.5).toFixed(2)),
+      timestamp: new Date(Date.now() - index * 60000).toISOString(),
+      features: {
+        tenureMonths: Math.floor(Math.random() * 24) + 1,
+        monthlyCharges: Number((Math.random() * 80 + 20).toFixed(2)),
+        supportTickets: Math.floor(Math.random() * 5),
+        contractType: index % 2 === 0 ? 'Two year' : 'Month-to-month'
+      }
+    };
+  }),
+  optimizationResults: [
+    {
+      strategy: 'Bayesian Optimization',
+      metric: 'AUC',
+      bestScore: 0.971,
+      bestParams: {
+        learning_rate: 0.08,
+        max_depth: 5,
+        subsample: 0.9,
+        colsample_bytree: 0.85
+      }
+    },
+    {
+      strategy: 'Random Search',
+      metric: 'F1 Score',
+      bestScore: 0.9,
+      bestParams: {
+        n_estimators: 500,
+        max_depth: 7,
+        min_child_weight: 3
+      }
+    }
+  ]
+};
+
+export async function fetchModelPerformance() {
+  await new Promise(resolve => setTimeout(resolve, 400));
+  return modelPerformanceMock;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,20 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f6fb;
+  color: #0f172a;
+}
+
+#root {
+  min-height: 100vh;
 }

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,0 +1,60 @@
+import { Box, Grid, Paper, Typography } from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import StorageIcon from '@mui/icons-material/Storage';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+
+const metrics = [
+  {
+    title: 'Active Projects',
+    value: '12',
+    caption: '3 new this week',
+    icon: <RocketLaunchIcon color="primary" />
+  },
+  {
+    title: 'Models in Production',
+    value: '8',
+    caption: 'Accuracy avg 92%',
+    icon: <TrendingUpIcon color="success" />
+  },
+  {
+    title: 'Storage Utilization',
+    value: '2.3 TB',
+    caption: '65% of quota',
+    icon: <StorageIcon color="warning" />
+  }
+];
+
+export default function DashboardPage() {
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <Typography variant="h4" fontWeight={600} color="primary.light">
+        Welcome back, Analyst
+      </Typography>
+      <Typography variant="body1" color="text.secondary">
+        Track your machine learning initiatives at a glance.
+      </Typography>
+      <Grid container spacing={3}>
+        {metrics.map(metric => (
+          <Grid item key={metric.title} xs={12} sm={6} md={4}>
+            <Paper elevation={2} sx={{ p: 3, backgroundColor: 'background.paper' }}>
+              <Box display="flex" alignItems="center" gap={2}>
+                {metric.icon}
+                <Box>
+                  <Typography variant="overline" color="text.secondary">
+                    {metric.title}
+                  </Typography>
+                  <Typography variant="h5" fontWeight={600} color="text.primary">
+                    {metric.value}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {metric.caption}
+                  </Typography>
+                </Box>
+              </Box>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/pages/ModelPerformancePage.js
+++ b/src/pages/ModelPerformancePage.js
@@ -1,0 +1,844 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Slider,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import TableChartOutlinedIcon from '@mui/icons-material/TableChartOutlined';
+import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import TrendingUpOutlinedIcon from '@mui/icons-material/TrendingUpOutlined';
+import InsightsOutlinedIcon from '@mui/icons-material/InsightsOutlined';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import { fetchModelPerformance } from '../data/performanceData';
+import MetricCard from '../components/common/MetricCard';
+import { exportModelSummaryPdf, exportPredictionsToCSV } from '../utils/exportUtils';
+import { alpha } from '@mui/material/styles';
+
+const metricDescriptors = [
+  { key: 'accuracy', label: 'Accuracy', icon: <TrendingUpOutlinedIcon /> },
+  { key: 'precision', label: 'Precision', icon: <ScienceOutlinedIcon /> },
+  { key: 'recall', label: 'Recall', icon: <TimelineOutlinedIcon /> },
+  { key: 'rocAuc', label: 'ROC AUC', icon: <InsightsOutlinedIcon /> }
+];
+
+const rocColors = ['#1173d4', '#4caf50', '#ff9800', '#f44336'];
+
+function formatPercentage(value) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function buildConfusionCells(run) {
+  const total = run.confusionMatrix.values.flat().reduce((sum, cell) => sum + cell, 0);
+  return run.confusionMatrix.values.map((row, rowIndex) =>
+    row.map((value, columnIndex) => ({
+      label: `${run.confusionMatrix.labels[rowIndex]} → ${run.confusionMatrix.labels[columnIndex]}`,
+      value,
+      percentage: value / total
+    }))
+  );
+}
+
+function ModelMetricsComparison({ models }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 3,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack spacing={0.5}>
+          <Typography variant="h6" color="text.primary" fontWeight={600}>
+            Model Comparison
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Evaluate performance metrics across selected models side by side.
+          </Typography>
+        </Stack>
+        <Chip label={`${models.length} models`} color="primary" variant="outlined" />
+      </Stack>
+      {models.length > 0 ? (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Model</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell align="center">Accuracy</TableCell>
+              <TableCell align="center">Precision</TableCell>
+              <TableCell align="center">Recall</TableCell>
+              <TableCell align="center">F1 Score</TableCell>
+              <TableCell align="center">ROC AUC</TableCell>
+              <TableCell align="center">Log Loss</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {models.map(model => (
+              <TableRow key={model.id} hover>
+                <TableCell>
+                  <Stack spacing={0.5}>
+                    <Typography variant="subtitle2" color="text.primary" fontWeight={600}>
+                      {model.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Version {model.version} · {new Date(model.updatedAt).toLocaleString()}
+                    </Typography>
+                  </Stack>
+                </TableCell>
+                <TableCell>{model.type}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.accuracy)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.precision)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.recall)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.f1Score)}</TableCell>
+                <TableCell align="center">{formatPercentage(model.metrics.rocAuc)}</TableCell>
+                <TableCell align="center">{model.metrics.logLoss.toFixed(3)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Paper
+          variant="outlined"
+          sx={{ p: 4, textAlign: 'center', backgroundColor: 'rgba(255,255,255,0.02)' }}
+        >
+          <Typography variant="subtitle1" color="text.primary" fontWeight={600} gutterBottom>
+            Select models to compare
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Choose one or more models from the filters above to unlock the comparison matrix.
+          </Typography>
+        </Paper>
+      )}
+    </Paper>
+  );
+}
+
+function ConfusionMatrixCard({ run }) {
+  const cells = buildConfusionCells(run);
+  const totals = run.confusionMatrix.values.map(row => row.reduce((sum, value) => sum + value, 0));
+  const columnTotals = run.confusionMatrix.values[0].map((_, columnIndex) =>
+    run.confusionMatrix.values.reduce((sum, row) => sum + row[columnIndex], 0)
+  );
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        height: '100%',
+        border: '1px solid rgba(255,255,255,0.08)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2
+      }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack spacing={0.5}>
+          <Typography variant="h6" fontWeight={600}>
+            Confusion Matrix
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Dataset: {run.dataset}
+          </Typography>
+        </Stack>
+        <Chip size="small" label={`Updated ${new Date(run.createdAt).toLocaleString()}`} variant="outlined" />
+      </Stack>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Actual / Predicted</TableCell>
+            {run.confusionMatrix.labels.map(label => (
+              <TableCell key={label} align="center">
+                {label}
+              </TableCell>
+            ))}
+            <TableCell align="center">Total</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {cells.map((row, rowIndex) => (
+            <TableRow key={run.confusionMatrix.labels[rowIndex]}>
+              <TableCell>{run.confusionMatrix.labels[rowIndex]}</TableCell>
+              {row.map(cell => (
+                <TableCell
+                  key={cell.label}
+                  align="center"
+                  sx={{
+                    backgroundColor: theme => alpha(theme.palette.primary.main, 0.08 + cell.percentage * 0.5),
+                    borderRadius: 1
+                  }}
+                >
+                  <Stack spacing={0.5}>
+                    <Typography variant="body2" fontWeight={600}>
+                      {cell.value}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {(cell.percentage * 100).toFixed(1)}%
+                    </Typography>
+                  </Stack>
+                </TableCell>
+              ))}
+              <TableCell align="center" sx={{ fontWeight: 600 }}>
+                {totals[rowIndex]}
+              </TableCell>
+            </TableRow>
+          ))}
+          <TableRow>
+            <TableCell>Total</TableCell>
+            {columnTotals.map((total, index) => (
+              <TableCell key={`col-${index}`} align="center" sx={{ fontWeight: 600 }}>
+                {total}
+              </TableCell>
+            ))}
+            <TableCell align="center" sx={{ fontWeight: 700 }}>
+              {totals.reduce((sum, value) => sum + value, 0)}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+}
+
+function PredictionTable({
+  predictions,
+  models,
+  selectedModelId,
+  onChangeModel,
+  threshold,
+  onThresholdChange,
+  onlyMisclassified,
+  onToggleMisclassified
+}) {
+  const [expanded, setExpanded] = useState(null);
+
+  const filteredPredictions = useMemo(() => {
+    return predictions
+      .filter(pred => pred.modelId === selectedModelId)
+      .filter(pred => (onlyMisclassified ? pred.actual !== pred.predicted : true))
+      .filter(pred => pred.probability >= threshold)
+      .slice(0, 12);
+  }, [predictions, selectedModelId, onlyMisclassified, threshold]);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }}>
+        <Stack spacing={0.5} flex={1}>
+          <Typography variant="h6" fontWeight={600}>
+            Prediction Drill-down
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Review recent predictions and explore contributing features for transparency.
+          </Typography>
+        </Stack>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center">
+          <FormControl size="small" sx={{ minWidth: 200 }}>
+            <InputLabel id="prediction-model-label">Model</InputLabel>
+            <Select
+              labelId="prediction-model-label"
+              value={selectedModelId}
+              label="Model"
+              onChange={event => onChangeModel(event.target.value)}
+            >
+              {models.map(model => (
+                <MenuItem key={model.id} value={model.id}>
+                  {model.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Typography variant="caption">Show misclassifications</Typography>
+            <Switch
+              checked={onlyMisclassified}
+              onChange={(_, checked) => onToggleMisclassified(checked)}
+              inputProps={{ 'aria-label': 'show only misclassified predictions' }}
+            />
+          </Stack>
+        </Stack>
+      </Stack>
+      <Stack spacing={1.5}>
+        <Typography variant="caption" color="text.secondary">
+          Probability threshold: {(threshold * 100).toFixed(0)}%
+        </Typography>
+        <Slider
+          value={threshold}
+          onChange={(_, value) => onThresholdChange(value)}
+          min={0.5}
+          max={0.95}
+          step={0.05}
+          valueLabelDisplay="auto"
+          valueLabelFormat={value => `${Math.round(value * 100)}%`}
+          marks={[
+            { value: 0.5, label: '50%' },
+            { value: 0.65, label: '65%' },
+            { value: 0.8, label: '80%' },
+            { value: 0.95, label: '95%' }
+          ]}
+        />
+        <Typography variant="caption" color="text.secondary">
+          Drag the slider to focus on high-confidence predictions for error analysis.
+        </Typography>
+      </Stack>
+      <Divider sx={{ borderColor: 'rgba(255,255,255,0.08)' }} />
+      <Stack spacing={1}>
+        {filteredPredictions.map(prediction => {
+          const misclassified = prediction.actual !== prediction.predicted;
+          return (
+            <Accordion
+              key={prediction.id}
+              expanded={expanded === prediction.id}
+              onChange={(_, isExpanded) => setExpanded(isExpanded ? prediction.id : null)}
+              disableGutters
+              sx={{
+                backgroundColor: 'transparent',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: 2,
+                '&:before': { display: 'none' }
+              }}
+            >
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Stack
+                  direction={{ xs: 'column', md: 'row' }}
+                  spacing={2}
+                  flex={1}
+                  alignItems={{ xs: 'flex-start', md: 'center' }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="center" flex={1}>
+                    {misclassified && <WarningAmberOutlinedIcon color="warning" fontSize="small" />}
+                    <Box>
+                      <Typography variant="subtitle2" color="text.primary" fontWeight={600}>
+                        Prediction {prediction.id}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {new Date(prediction.timestamp).toLocaleString()}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                  <Chip
+                    label={`Actual: ${prediction.actual}`}
+                    color="secondary"
+                    variant="outlined"
+                    sx={{ minWidth: 120 }}
+                  />
+                  <Chip
+                    label={`Predicted: ${prediction.predicted}`}
+                    color={misclassified ? 'warning' : 'success'}
+                    variant={misclassified ? 'outlined' : 'filled'}
+                    sx={{ minWidth: 140 }}
+                  />
+                  <Chip
+                    label={`Confidence ${(prediction.probability * 100).toFixed(0)}%`}
+                    color="primary"
+                    variant="outlined"
+                    sx={{ minWidth: 160 }}
+                  />
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  {Object.entries(prediction.features).map(([feature, value]) => (
+                    <Grid item xs={12} sm={6} md={3} key={feature}>
+                      <Paper
+                        variant="outlined"
+                        sx={{
+                          p: 2,
+                          borderRadius: 2,
+                          backgroundColor: alpha('#ffffff', 0.02)
+                        }}
+                      >
+                        <Typography variant="caption" color="text.secondary" textTransform="uppercase">
+                          {feature}
+                        </Typography>
+                        <Typography variant="subtitle1" color="text.primary" fontWeight={600}>
+                          {value}
+                        </Typography>
+                      </Paper>
+                    </Grid>
+                  ))}
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+          );
+        })}
+        {filteredPredictions.length === 0 && (
+          <Paper
+            variant="outlined"
+            sx={{ p: 4, textAlign: 'center', backgroundColor: 'rgba(255,255,255,0.02)' }}
+          >
+            <Typography variant="subtitle1" color="text.primary" fontWeight={600} gutterBottom>
+              No predictions match the current filters
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Adjust the confidence threshold or toggle misclassifications to explore more predictions.
+            </Typography>
+          </Paper>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+function RocCurve({ series, baseline }) {
+  const ticks = [0, 0.25, 0.5, 0.75, 1];
+
+  const toPoint = point => {
+    const x = point.fpr * 100;
+    const y = (1 - point.tpr) * 100;
+    return `${x},${y}`;
+  };
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+      <svg viewBox="0 0 100 100" preserveAspectRatio="none" style={{ width: '100%', height: '100%' }}>
+        <rect x="0" y="0" width="100" height="100" fill="transparent" stroke="rgba(255,255,255,0.2)" />
+        {ticks.map(tick => (
+          <line
+            key={`h-${tick}`}
+            x1="0"
+            y1={(1 - tick) * 100}
+            x2="100"
+            y2={(1 - tick) * 100}
+            stroke="rgba(255,255,255,0.06)"
+            strokeDasharray="2 4"
+          />
+        ))}
+        {ticks.map(tick => (
+          <line
+            key={`v-${tick}`}
+            x1={tick * 100}
+            y1="0"
+            x2={tick * 100}
+            y2="100"
+            stroke="rgba(255,255,255,0.06)"
+            strokeDasharray="2 4"
+          />
+        ))}
+        <polyline
+          points={baseline.map(toPoint).join(' ')}
+          fill="none"
+          stroke="rgba(255,255,255,0.3)"
+          strokeDasharray="4 4"
+          strokeWidth="2"
+        />
+        {series.map((serie, index) => (
+          <polyline
+            key={serie.name}
+            points={serie.data.map(toPoint).join(' ')}
+            fill="none"
+            stroke={rocColors[index % rocColors.length]}
+            strokeWidth="2"
+          />
+        ))}
+        {series.map((serie, seriesIndex) =>
+          serie.data.map((point, pointIndex) => (
+            <circle
+              key={`${serie.name}-${pointIndex}`}
+              cx={point.fpr * 100}
+              cy={(1 - point.tpr) * 100}
+              r={1.8}
+              fill={rocColors[seriesIndex % rocColors.length]}
+            />
+          ))
+        )}
+        <text x="50" y="108" textAnchor="middle" fill="rgba(255,255,255,0.7)" fontSize="6">
+          False Positive Rate
+        </text>
+        <text
+          x="-50"
+          y="-6"
+          transform="rotate(-90)"
+          textAnchor="middle"
+          fill="rgba(255,255,255,0.7)"
+          fontSize="6"
+        >
+          True Positive Rate
+        </text>
+        {ticks.map(tick => (
+          <text
+            key={`x-label-${tick}`}
+            x={tick * 100}
+            y="105"
+            textAnchor="middle"
+            fill="rgba(255,255,255,0.6)"
+            fontSize="5"
+          >
+            {Math.round(tick * 100)}%
+          </text>
+        ))}
+        {ticks.map(tick => (
+          <text
+            key={`y-label-${tick}`}
+            x="-4"
+            y={(1 - tick) * 100 + 1.5}
+            textAnchor="end"
+            fill="rgba(255,255,255,0.6)"
+            fontSize="5"
+          >
+            {Math.round(tick * 100)}%
+          </text>
+        ))}
+      </svg>
+    </Box>
+  );
+}
+
+export default function ModelPerformancePage() {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedModelIds, setSelectedModelIds] = useState([]);
+  const [selectedDataset, setSelectedDataset] = useState('');
+  const [selectedMetric, setSelectedMetric] = useState('accuracy');
+  const [predictionModelId, setPredictionModelId] = useState('');
+  const [threshold, setThreshold] = useState(0.6);
+  const [onlyMisclassified, setOnlyMisclassified] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    fetchModelPerformance().then(response => {
+      if (!mounted) return;
+      setData(response);
+      const defaults = response.models.slice(0, 2).map(model => model.id);
+      setSelectedModelIds(defaults);
+      setPredictionModelId(defaults[0] ?? response.models[0]?.id ?? '');
+      setSelectedDataset(response.models[0]?.dataset ?? '');
+      setIsLoading(false);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const datasetOptions = useMemo(
+    () => Array.from(new Set(data?.models.map(model => model.dataset) ?? [])),
+    [data]
+  );
+
+  const datasetModels = useMemo(
+    () => data?.models.filter(model => !selectedDataset || model.dataset === selectedDataset) ?? [],
+    [data, selectedDataset]
+  );
+
+  const selectedModels = useMemo(
+    () => datasetModels.filter(model => selectedModelIds.includes(model.id)),
+    [datasetModels, selectedModelIds]
+  );
+
+  const selectedRuns = useMemo(
+    () =>
+      data?.performanceRuns.filter(
+        run => selectedModelIds.includes(run.modelId) && run.dataset === selectedDataset
+      ) ?? [],
+    [data, selectedModelIds, selectedDataset]
+  );
+
+  const metricLeaders = useMemo(() => {
+    if (!datasetModels.length) return [];
+    return metricDescriptors.map(descriptor => {
+      const leader = [...datasetModels].sort(
+        (a, b) => b.metrics[descriptor.key] - a.metrics[descriptor.key]
+      )[0];
+      return {
+        descriptor,
+        leader
+      };
+    });
+  }, [datasetModels]);
+
+  const rocSeries = useMemo(() => {
+    return selectedRuns.map(run => ({
+      name: data?.models.find(model => model.id === run.modelId)?.name ?? run.modelId,
+      data: run.roc
+    }));
+  }, [selectedRuns, data]);
+
+  useEffect(() => {
+    if (!datasetModels.length) {
+      if (selectedModelIds.length) {
+        setSelectedModelIds([]);
+      }
+      if (predictionModelId) {
+        setPredictionModelId('');
+      }
+      return;
+    }
+
+    const intersection = selectedModelIds.filter(id =>
+      datasetModels.some(model => model.id === id)
+    );
+
+    if (intersection.length === 0) {
+      const defaults = datasetModels.slice(0, 2).map(model => model.id);
+      if (defaults.length) {
+        setSelectedModelIds(defaults);
+        setPredictionModelId(defaults[0]);
+      }
+    } else if (intersection.length !== selectedModelIds.length) {
+      setSelectedModelIds(intersection);
+    }
+  }, [datasetModels, selectedModelIds, predictionModelId]);
+
+  useEffect(() => {
+    if (selectedModelIds.length && !selectedModelIds.includes(predictionModelId)) {
+      setPredictionModelId(selectedModelIds[0]);
+    }
+  }, [selectedModelIds, predictionModelId]);
+
+  const diagonalPoints = useMemo(
+    () => Array.from({ length: 11 }, (_, index) => ({ fpr: index / 10, tpr: index / 10 })),
+    []
+  );
+
+  const filteredPredictions = data?.predictions ?? [];
+
+  const handleExportCsv = () => {
+    if (!filteredPredictions.length) return;
+    exportPredictionsToCSV(filteredPredictions, 'model-predictions.csv');
+  };
+
+  const handleExportPdf = () => {
+    if (!selectedModels.length) return;
+    exportModelSummaryPdf(selectedModels, 'model-performance-report.pdf');
+  };
+
+  if (isLoading || !data) {
+    return (
+      <Paper sx={{ p: 6, display: 'flex', justifyContent: 'center', backgroundColor: 'rgba(255,255,255,0.04)' }}>
+        <Stack spacing={2} alignItems="center">
+          <CircularProgress color="primary" />
+          <Typography variant="body2" color="text.secondary">
+            Aggregating performance analytics…
+          </Typography>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap={4}>
+      <Paper
+        elevation={0}
+        sx={{
+          p: 3,
+          border: '1px solid rgba(255,255,255,0.08)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 3
+        }}
+      >
+        <Stack direction={{ xs: 'column', lg: 'row' }} spacing={3} alignItems={{ xs: 'flex-start', lg: 'center' }}>
+          <Stack spacing={0.5} flex={1}>
+            <Typography variant="h5" fontWeight={700} color="text.primary">
+              Model Performance Intelligence
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Monitor, compare, and explain how your production models behave across datasets, thresholds, and metrics.
+            </Typography>
+          </Stack>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+            <Button
+              variant="outlined"
+              color="secondary"
+              startIcon={<TableChartOutlinedIcon />}
+              onClick={handleExportCsv}
+            >
+              Export predictions (CSV)
+            </Button>
+            <Button variant="contained" color="primary" startIcon={<DownloadOutlinedIcon />} onClick={handleExportPdf}>
+              Download Summary Report
+            </Button>
+          </Stack>
+        </Stack>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="dataset-select-label">Dataset</InputLabel>
+            <Select
+              labelId="dataset-select-label"
+              value={selectedDataset}
+              label="Dataset"
+              onChange={event => setSelectedDataset(event.target.value)}
+            >
+              {datasetOptions.map(dataset => (
+                <MenuItem key={dataset} value={dataset}>
+                  {dataset}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel id="metric-select-label">Primary metric</InputLabel>
+            <Select
+              labelId="metric-select-label"
+              value={selectedMetric}
+              label="Primary metric"
+              onChange={event => setSelectedMetric(event.target.value)}
+            >
+              {metricDescriptors.map(descriptor => (
+                <MenuItem key={descriptor.key} value={descriptor.key}>
+                  {descriptor.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel id="model-select-label">Models</InputLabel>
+            <Select
+              labelId="model-select-label"
+              multiple
+              value={selectedModelIds}
+              label="Models"
+              onChange={event => setSelectedModelIds(event.target.value)}
+              renderValue={selected =>
+                selected
+                  .map(id => datasetModels.find(model => model.id === id)?.name ?? id)
+                  .join(', ')
+              }
+            >
+              {datasetModels.map(model => (
+                <MenuItem key={model.id} value={model.id}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Typography variant="body2" color="text.primary">
+                      {model.name}
+                    </Typography>
+                    <Chip label={model.type} size="small" color="secondary" variant="outlined" />
+                  </Stack>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+      </Paper>
+
+      <Grid container spacing={3}>
+        {metricLeaders.map(({ descriptor, leader }) => (
+          <Grid item xs={12} sm={6} lg={3} key={descriptor.key}>
+            <MetricCard
+              title={descriptor.label}
+              value={leader ? formatPercentage(leader.metrics[descriptor.key]) : '--'}
+              subtitle={leader ? leader.name : 'No data'}
+              icon={descriptor.icon}
+              color="primary"
+              trend={selectedMetric === descriptor.key ? 'up' : 'stable'}
+              trendValue={leader ? `${formatPercentage(leader.metrics[descriptor.key])}` : undefined}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      <Grid container spacing={3}>
+        {selectedRuns.map(run => (
+          <Grid item xs={12} md={6} key={run.id}>
+            <ConfusionMatrixCard run={run} />
+          </Grid>
+        ))}
+        <Grid item xs={12} md={selectedRuns.length > 1 ? 12 : 6}>
+          <Paper
+            elevation={0}
+            sx={{
+              p: 3,
+              border: '1px solid rgba(255,255,255,0.08)',
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 3
+            }}
+          >
+            <Stack direction="row" alignItems="center" justifyContent="space-between">
+              <Stack spacing={0.5}>
+                <Typography variant="h6" fontWeight={600}>
+                  ROC Curve
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Compare true positive rates against false positive rates across thresholds.
+                </Typography>
+              </Stack>
+              <Tooltip title="Area under the curve indicates overall model discrimination power.">
+                <IconButton color="inherit">
+                  <InfoOutlinedIcon />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+            <Box sx={{ position: 'relative', height: { xs: 300, md: 360 } }}>
+              <RocCurve series={rocSeries} baseline={diagonalPoints} />
+            </Box>
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems="center" flexWrap="wrap">
+              {rocSeries.map((series, index) => (
+                <Stack key={series.name} direction="row" spacing={1} alignItems="center">
+                  <Box
+                    sx={{
+                      width: 12,
+                      height: 12,
+                      borderRadius: 999,
+                      backgroundColor: rocColors[index % rocColors.length]
+                    }}
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    {series.name}
+                  </Typography>
+                </Stack>
+              ))}
+              {!rocSeries.length && (
+                <Typography variant="caption" color="text.secondary">
+                  Select a model to visualize its ROC curve.
+                </Typography>
+              )}
+            </Stack>
+          </Paper>
+        </Grid>
+      </Grid>
+
+      <ModelMetricsComparison models={selectedModels} />
+
+      <PredictionTable
+        predictions={filteredPredictions}
+        models={selectedModels.length ? selectedModels : datasetModels.length ? datasetModels : data.models}
+        selectedModelId={
+          predictionModelId || selectedModels[0]?.id || datasetModels[0]?.id || data.models[0].id
+        }
+        onChangeModel={setPredictionModelId}
+        threshold={threshold}
+        onThresholdChange={setThreshold}
+        onlyMisclassified={onlyMisclassified}
+        onToggleMisclassified={setOnlyMisclassified}
+      />
+    </Box>
+  );
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,78 @@
+import { createTheme } from '@mui/material/styles';
+
+const auroraTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#1173d4',
+      light: '#4095f4'
+    },
+    secondary: {
+      main: '#283039'
+    },
+    background: {
+      default: '#111418',
+      paper: '#181C20'
+    },
+    text: {
+      primary: '#ffffff',
+      secondary: '#9dabb9'
+    },
+    success: {
+      main: '#4caf50'
+    },
+    warning: {
+      main: '#ff9800'
+    },
+    error: {
+      main: '#f44336'
+    }
+  },
+  typography: {
+    fontFamily: ['Inter', 'Noto Sans', 'sans-serif'].join(','),
+    h1: { fontWeight: 700 },
+    h2: { fontWeight: 700 },
+    h3: { fontWeight: 600 },
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 600 },
+    h6: { fontWeight: 600 },
+    subtitle1: { fontWeight: 500 },
+    subtitle2: { fontWeight: 500 }
+  },
+  shape: {
+    borderRadius: 12
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          backgroundColor: '#181C20',
+          borderRadius: 16
+        }
+      }
+    },
+    MuiButton: {
+      defaultProps: {
+        variant: 'contained'
+      },
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          borderRadius: 12,
+          fontWeight: 600
+        }
+      }
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 20,
+          backgroundImage: 'none'
+        }
+      }
+    }
+  }
+});
+
+export default auroraTheme;

--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -1,0 +1,63 @@
+function downloadFile(content, filename, type) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function exportPredictionsToCSV(predictions, filename = 'predictions.csv') {
+  if (!predictions.length) return;
+
+  const headers = ['ID', 'Model', 'Actual', 'Predicted', 'Probability', 'Timestamp'];
+  const featureKeys = Array.from(
+    new Set(predictions.flatMap(pred => Object.keys(pred.features ?? {})))
+  );
+
+  const rows = predictions.map(pred => [
+    pred.id,
+    pred.modelId,
+    pred.actual,
+    pred.predicted,
+    pred.probability.toString(),
+    pred.timestamp,
+    ...featureKeys.map(key => String(pred.features?.[key] ?? ''))
+  ]);
+
+  const csvContent = [headers.concat(featureKeys), ...rows]
+    .map(row => row.map(value => `"${String(value).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+
+  downloadFile(csvContent, filename, 'text/csv;charset=utf-8;');
+}
+
+export function exportModelSummaryPdf(models, filename = 'model-performance-report.txt') {
+  if (!models.length) return;
+
+  const header = 'Model Performance Summary\n';
+  const generated = `Generated: ${new Date().toLocaleString()}\n\n`;
+  const columns = ['Model', 'Type', 'Version', 'Dataset', 'Accuracy', 'Precision', 'Recall', 'F1 Score', 'ROC AUC'];
+  const table = [columns.join('\t')]
+    .concat(
+      models.map(model =>
+        [
+          model.name,
+          model.type,
+          model.version,
+          model.dataset,
+          (model.metrics.accuracy * 100).toFixed(2) + ' %',
+          (model.metrics.precision * 100).toFixed(2) + ' %',
+          (model.metrics.recall * 100).toFixed(2) + ' %',
+          (model.metrics.f1Score * 100).toFixed(2) + ' %',
+          (model.metrics.rocAuc * 100).toFixed(2) + ' %'
+        ].join('\t')
+      )
+    )
+    .join('\n');
+
+  downloadFile(header + generated + table, filename, 'text/plain;charset=utf-8;');
+}


### PR DESCRIPTION
## Summary
- replace the MUI-driven navigation shell with a static layout that mirrors the MLFlow Pro dashboard structure and copy
- implement bespoke components for the sidebar, header, welcome hero, stats panels, and meeting cards using custom CSS
- introduce a dedicated stylesheet to recreate the light theme palette, gradients, and iconography from the reference design while updating the global color scheme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15581ca608331952e02a2b3784720